### PR TITLE
Convert Google Code wiki docs to GitHub Markdown

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,32 +1,53 @@
-#summary Summary of recent changes to the code.
+# Summary of recent changes to the code
 
-  * *Jul 17, 2012*
-    * Fixed bug in contrast normalization backpropagation code which caused wrong gradients to be computed near image borders. (Thanks Hannes Schulz).
-  * *Mar 13, 2012*
-    * Added [LayerParams#Local_response_normalization_layer_(across_maps) response-normalization across maps] layer.
-    * Started modifying the code to support rectangular (i.e. non-square) images. The convolution code now supports rectangular images, but the remaining code does not yet. So the whole package still requires square images.
-  * *Feb 8, 2012*
-    * Most layer types now should work well with minibatch size 64 or 32.
-    * Fixed --conserve-mem option so it can be combined with -f (i.e. its value can be changed after a net has been saved).
-  * *Feb 3, 2012*
-    * Convolution with minibatch sizes 32 or 64 should now be about twice as fast (though it's still most optimized for minibatch sizes divisible by 128).
-    * Added [Options --conserve-mem] parameter.
-  * *Jan 22, 2012*
-    * Added some [LayerParams#Color_space_manipulation_layers color space manipulation layers].
-  * *Jan 11, 2012*
-    * Added [LayerParams#Image_resizing_layer image resizing with bilinear filtering] layer.
-  * *Dec 28, 2011*
-    * Added ability to [LayerParams#Initializing_weights_from_an_outside_source initialize weights from an outside source]. Thanks to Oriol Vinyals for the suggestion.
-    * Layers with zero learning rate no longer waste time computing the gradient.
-  * *Dec 22, 2011*
-    * Added elementwise max layer, to allow (for example) pooling over scale.
-    * Added square, square root neuron activation functions.
-    * Added sum-of-squares objective.
-  * *Dec 17, 2011*
-    * Added Gaussian blur and "bed of nails" subsampling layers.
-  * *Dec 9, 2011*
-    * All layers with weights (and some others) can now take multiple layers as input.
-    * Added the "sum" layer type, which simply performs an elementwise sum of all its input layers.
-    * Added support for weight sharing between different layers of the same type. One of the things this allows you to do is to write recurrent networks. Thanks to Ilya Sutskever for the suggestion.
-    * Decoupled neuron activation functions from the few layers that supported them. Now you can add a "neuron" layer anywhere in the net, which applies some elementwise function to its input.
-    * Most layers now take a neuron=x parameter, which applies some neuron activation function to their outputs.
+* *Jul 17, 2012*
+  * Fixed bug in contrast normalization backpropagation code which caused wrong
+    gradients to be computed near image borders. (Thanks Hannes Schulz).
+
+* *Mar 13, 2012*
+  * Added [response-normalization across maps](LayerParams.md#local-response-normalization-layer-across-maps) layer.
+  * Started modifying the code to support rectangular (i.e. non-square) images.
+    The convolution code now supports rectangular images, but the remaining code
+    does not yet. So the whole package still requires square images.
+
+* *Feb 8, 2012*
+  * Most layer types now should work well with minibatch size 64 or 32.
+  * Fixed `--conserve-mem` option so it can be combined with `-f` (i.e. its
+    value can be changed after a net has been saved).
+
+* *Feb 3, 2012*
+  * Convolution with minibatch sizes 32 or 64 should now be about twice as fast
+    (though it's still most optimized for minibatch sizes divisible by 128).
+  * Added [`--conserve-mem`](Options.md) parameter.
+
+* *Jan 22, 2012*
+  * Added some [color space manipulation layers](LayerParams.md#color-space-manipulation-layers).
+
+* *Jan 11, 2012*
+  * Added [image resizing with bilinear filtering](LayerParams.md#image-resizing-layer) layer.
+
+* *Dec 28, 2011*
+  * Added ability to [initialize weights from an outside source](LayerParams.md#initializing-weights-from-an-outside-source). Thanks to Oriol Vinyals for the suggestion.
+  * Layers with zero learning rate no longer waste time computing the gradient.
+
+* *Dec 22, 2011*
+  * Added elementwise max layer, to allow (for example) pooling over scale.
+  * Added square, square root neuron activation functions.
+  * Added sum-of-squares objective.
+
+* *Dec 17, 2011*
+  * Added Gaussian blur and "bed of nails" subsampling layers.
+
+* *Dec 9, 2011*
+  * All layers with weights (and some others) can now take multiple layers as
+    input.
+  * Added the "sum" layer type, which simply performs an elementwise sum of all
+    its input layers.
+  * Added support for weight sharing between different layers of the same type.
+    One of the things this allows you to do is to write recurrent networks.
+    Thanks to Ilya Sutskever for the suggestion.
+  * Decoupled neuron activation functions from the few layers that supported
+    them. Now you can add a "neuron" layer anywhere in the net, which applies
+    some elementwise function to its input.
+  * Most layers now take a neuron=x parameter, which applies some neuron
+    activation function to their outputs.

--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -1,51 +1,61 @@
-#summary How to compile the code.
+# How to compile the code
 
-<font color="red">*Note*:</font> A Fermi-generation GPU (GTX 4xx, GTX 5xx, or Tesla equivalent) is required to run this code. Older GPUs won't work. Newer (Kepler) GPUs also will work, but as the GTX 680 is a terrible, terrible GPU for non-gaming purposes, I would not recommend that you use it. (It will be slow).
+**Note:** A Fermi-generation GPU (GTX 4xx, GTX 5xx, or Tesla equivalent) is
+required to run this code. Older GPUs won't work. Newer (Kepler) GPUs also will
+work, but as the GTX 680 is a terrible, terrible GPU for non-gaming purposes, I
+would not recommend that you use it. (It will be slow).
 
-= On Linux =
+## On Linux
 
-== Required libraries ==
+### Required libraries
 
-Here's what I hope to be a complete list of prerequisite libraries. Please [mailto:akrizhevsky@gmail.com email me] if I'm wrong.
+Here's what I hope to be a complete list of prerequisite libraries. Please
+[email me](mailto:akrizhevsky@gmail.com) if I'm wrong.
 
-|| *Library* || *Ubuntu package name* || *Fedora package name* ||
-|| Python development libraries/headers || python-dev || python-devel ||
-|| Numpy || python-numpy || numpy ||
-|| Python libmagic bindings || python-magic || python-magic ||
-|| Matplotlib || python-matplotlib || python-matplotlib ||
-|| ATLAS development libraries/headers || libatlas-base-dev || atlas-devel ||
+| Library | Ubuntu package name | Fedora package name |
+|---------|---------------------|---------------------|
+| Python development libraries/headers | python-dev | python-devel |
+| Numpy | python-numpy | numpy |
+| Python libmagic bindings | python-magic | python-magic |
+| Matplotlib | python-matplotlib | python-matplotlib |
+| ATLAS development libraries/headers | libatlas-base-dev | atlas-devel |
 
-Implicit in this list are all the packages on which the above packages depend (for example, python-magic depends on libmagic, etc.).
+Implicit in this list are all the packages on which the above packages depend
+(for example, python-magic depends on libmagic, etc.).
 
-And of course you also need to install the CUDA toolkit and CUDA SDK (versions 4.0, 4.1, and 4.2 will work).
+And of course you also need to install the CUDA toolkit and CUDA SDK (versions
+4.0, 4.1, and 4.2 will work).
 
-Ideally you should be running a 64-bit Linux system, as I do not know whether this code works on 32-bit systems.
+Ideally you should be running a 64-bit Linux system, as I do not know whether
+this code works on 32-bit systems.
 
-== Checking out the code ==
+### Compiling
 
-You can check out the code from trunk with this line:
-
-{{{
-svn checkout http://cuda-convnet.googlecode.com/svn/trunk/ cuda-convnet-read-only
-}}}
-
-== Compiling ==
-
-In the main directory, you'll find the [http://code.google.com/p/cuda-convnet/source/browse/trunk/build.sh build.sh] file. Fill in the environment variables in that file (the included defaults are the proper values on _my_ system, but almost certainly not on yours).
+In the main directory, you'll find the [`build.sh`](../build.sh) file. Fill in
+the environment variables in that file (the included defaults are the proper
+values on _my_ system, but almost certainly not on yours).
 
 Then, type
-{{{
+
+```sh
 sh build.sh
-}}}
+```
 
-If all goes well, in a few minutes the compilation will finish successfully. [mailto:akrizhevsky@gmail.com Email me] in case of trouble.
+If all goes well, in a few minutes the compilation will finish successfully.
+[Email me](mailto:akrizhevsky@gmail.com) in case of trouble.
 
-= On Windows =
-It's possible, but perhaps not easy, to compile and use this code on Windows. I have no means of testing it myself, but Oriol Vinyals has kindly provided [http://code.google.com/p/cuda-convnet/downloads/detail?name=cuda-convnet-vs-proj.zip this Visual Studio 2010 project] with which he was able to compile and run the code.
+## On Windows
+
+It's possible, but perhaps not easy, to compile and use this code on Windows. I
+have no means of testing it myself, but Oriol Vinyals has kindly provided [this
+Visual Studio 2010
+project](http://code.google.com/p/cuda-convnet/downloads/detail?name=cuda-convnet-vs-proj.zip)
+with which he was able to compile and run the code.
 
 He notes that you will have to
-  * Point Visual Studio to the location of your MKL install.
-  * Compile with the `USE_MKL` preprocessor macro defined.
-  * Replace the dependency on pthreads with [http://sourceware.org/pthreads-win32/ pthreads-win32].
+
+* Point Visual Studio to the location of your MKL install.
+* Compile with the `USE_MKL` preprocessor macro defined.
+* Replace the dependency on pthreads with [pthreads-win32](https://sourceware.org/pthreads-win32/).
 
 Good luck.

--- a/docs/Data.md
+++ b/docs/Data.md
@@ -1,16 +1,20 @@
-#summary Data format for the net.
+# Data format for the net
 
-= Introduction =
+## Introduction
 
 This code is capable of training on images of any (square) size, and with any number of channels (colors, if you like).
 
-= Data files =
+## Data files
 
-The net expects data to be stored as python pickled objects. You can find some example data here: http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz. This is the CIFAR-10 dataset.
+The net expects data to be stored as python pickled objects. You can find some
+example data
+[here](http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz). This is the
+CIFAR-10 dataset.
 
-The data must be broken down into batches. For example, the data above is broken down into 6 batches of 10000 cases:
+The data must be broken down into batches. For example, the data above is broken
+down into 6 batches of 10000 cases:
 
-{{{
+```
 ls -al /storage2/tiny/cifar-10-py-colmajor
 total 181892
 drwxr-xr-x  2 spoon spoon     4096 2011-06-26 13:19 .
@@ -22,41 +26,73 @@ drwxr-xr-x 34 spoon spoon     4096 2011-06-29 21:40 ..
 -rw-r--r--  1 spoon spoon 31035671 2011-06-26 13:20 data_batch_4
 -rw-r--r--  1 spoon spoon 31035598 2011-06-26 13:20 data_batch_5
 -rw-r--r--  1 spoon spoon 31035501 2011-06-26 13:20 data_batch_6
-}}}
+```
 
 Ideally, your test/validation data should be in a separate file from the other files. Here batch 6 is the test set.
 
-Inside the [http://code.google.com/p/cuda-convnet/source/browse/trunk/include/util.cuh util.cuh] file, there's this line:
-{{{
+Inside the [`util.cuh`](../include/util.cuh util.cuh) file, there's this line:
+
+```
 /*
  * Store entire data matrix on GPU if its size does not exceed this many MB.
  * Otherwise store only one minibatch at a time.
  */
 #define MAX_DATA_ON_GPU             200
-}}}
+```
 
-So, if your batch size isn't too big, it will correspond to the amount of data copied to the GPU at a time. Otherwise only one minibatch will be copied at a time, and the batch size will not have much meaning at all.
+So, if your batch size isn't too big, it will correspond to the amount of data
+copied to the GPU at a time. Otherwise only one minibatch will be copied at a
+time, and the batch size will not have much meaning at all.
 
-= Internal data layout =
-Here you have some freedom. The internals of the files are left up to you; you just have to write a data provider (a python class) to parse the files and return the data in a format that the model will understand. See [http://code.google.com/p/cuda-convnet/source/browse/trunk/convdata.py convdata.py] for some examples.
+## Internal data layout
 
-Keeping in mind the example of `CIFARDataProvider` in [http://code.google.com/p/cuda-convnet/source/browse/trunk/convdata.py convdata.py], you can see that the data provider defines a `get_next_batch` function which returns a data matrix and a labels vector. There are a few other constraints on the data provider:
-  * The data provider must define a function `get_data_dims(self, idx=0)`, which returns the data dimensionality of each matrix returned by `get_next_batch`.
-  * The data matrix must be C-ordered (this is the default for numpy arrays), with dimensions `(data dimensionality)x(number of cases)`. If your images have channels (for example, the 3 color channels in the CIFAR-10), then all the values for channel `n` must precede all the values for channel `n + 1`.
-  * The data matrix must consist of *single-precision floats*.
+Here you have some freedom. The internals of the files are left up to you; you
+just have to write a data provider (a python class) to parse the files and
+return the data in a format that the model will understand. See
+[`convdata.py`](../convdata.py) for some examples.
 
-Assuming you're going to use the logistic regression objective built into the code rather than write your own, there are a few additional constraints on the data provider:
-  * The labels vector (returned by `get_next_batch`) must have dimensionality `1x(number of cases)`.
-  * The elements of the labels vector must range from 0 until the number of classes minus one.
-  * The labels vector must consist of *single-precision floats*.
-  * The data provider must define a function `get_num_classes(self)` which simply returns the number of classes in your dataset. The `CIFARDataProvider` inherits this function from `LabeledDataProvider` defined in [http://code.google.com/p/cuda-convnet/source/browse/trunk/data.py data.py].
+Keeping in mind the example of `CIFARDataProvider` in
+[`convdata.py`](../convdata.py), you can see that the data provider defines a
+`get_next_batch` function which returns a data matrix and a labels vector. There
+are a few other constraints on the data provider:
+
+* The data provider must define a function `get_data_dims(self, idx=0)`, which
+  returns the data dimensionality of each matrix returned by `get_next_batch`.
+* The data matrix must be C-ordered (this is the default for numpy arrays), with
+  dimensions `(data dimensionality)x(number of cases)`. If your images have
+  channels (for example, the 3 color channels in the CIFAR-10), then all the
+  values for channel `n` must precede all the values for channel `n + 1`.
+* The data matrix must consist of *single-precision floats*.
+
+Assuming you're going to use the logistic regression objective built into the
+code rather than write your own, there are a few additional constraints on the
+data provider:
+
+* The labels vector (returned by `get_next_batch`) must have dimensionality
+  `1x(number of cases)`.
+* The elements of the labels vector must range from 0 until the number of
+  classes minus one.
+* The labels vector must consist of *single-precision floats*.
+* The data provider must define a function `get_num_classes(self)` which simply
+  returns the number of classes in your dataset. The `CIFARDataProvider`
+  inherits this function from `LabeledDataProvider` defined in
+  [`data.py`](../data.py).
 
 Aside from that, there isn't much to trip over.
 
-= Included data providers =
-This code ships with three data providers. You can find them all in [http://code.google.com/p/cuda-convnet/source/browse/trunk/convdata.py convdata.py].
-  * `CIFARDataProvider` is used to parse the CIFAR-10 dataset. See TrainingNet for details.
-  * `CroppedCifarDataProvider` is used to parse and crop the CIFAR-10 dataset. This is useful if you want to train on translations of the CIFAR-10 images. See [TrainingNet#Training_on_image_translations] for details.
-  * `DummyConvNetDataProvider` is used to generate dummy data for gradient-testing computations. See CheckingGradients for details.
+## Included data providers
 
-Once you've written a new data provider to parse your data, you can register it at the bottom of the [http://code.google.com/p/cuda-convnet/source/browse/trunk/convnet.py convnet.py] file with the `DataProvider.register_data_provider` function, as shown there.
+This code ships with three data providers. You can find them all in
+[`convdata.py`](../convdata.py).
+
+* `CIFARDataProvider` is used to parse the CIFAR-10 dataset. See [training
+  net](TrainingNet.md) for details.
+* `CroppedCifarDataProvider` is used to parse and crop the CIFAR-10 dataset.
+  This is useful if you want to train on translations of the CIFAR-10 images.
+  See [training net](TrainingNet.md#Training_on_image_translations) for details.
+* `DummyConvNetDataProvider` is used to generate dummy data for gradient-testing
+  computations. See CheckingGradients for details.
+
+Once you've written a new data provider to parse your data, you can register it
+at the bottom of the [`convnet.py`](../convnet.py) file with the
+`DataProvider.register_data_provider` function, as shown there.

--- a/docs/LayerParams.md
+++ b/docs/LayerParams.md
@@ -1,19 +1,19 @@
-#summary How to specify a neural net architecture.
+# How to specify a neural net architecture
 
-<h1>Table of Contents</h1>
-<wiki:toc max_depth="2" />
+## Introduction
 
-= Introduction =
+To define the architecture of your neural net, you must write a layer definition
+file. You can find several complete and working [layer definition
+files](../example-layers). In this section I will go over the types of layers
+supported by the net, and how to specify them.
 
-To define the architecture of your neural net, you must write a layer definition file. You can find several complete and working layer definition files [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/ here]. In this section I will go over the types of layers supported by the net, and how to specify them.
+## Layer definition file - basic features
 
-=Layer definition file - basic features =
-
-==Data layer==
+### Data layer
 
 The first thing you might add to your layer definition file is a data layer.
 
-{{{
+```ini
 [data]
 type=data
 dataIdx=0
@@ -23,19 +23,26 @@ type=data
 dataIdx=1
 
 # By the way, this is a comment.
-}}}
+```
 
-The things in square brackets are user-friendly layer names, and they can be whatever you want them to be. Here we're really defining two layers: one we're calling *data* and the other we're calling *labels*.
+The things in square brackets are user-friendly layer names, and they can be
+whatever you want them to be. Here we're really defining two layers: one we're
+calling `data` and the other we're calling `labels`.
 
-The *type=data* line indicates that this is a data layer.
+The `type=data` line indicates that this is a data layer.
 
-Our python [Data data provider] outputs a list of two elements: the CIFAR-10 images and the CIFAR-10 labels. The line *dataIdx=0* indicates that the layer named *data* is mapped to the CIFAR-10 images, and similarly the line *dataIdx=1* indicates that the layer named *labels* is mapped to the CIFAR-10 labels.
+Our python [data provider](Data.md) outputs a list of two elements: the CIFAR-10
+images and the CIFAR-10 labels. The line `dataIdx=0` indicates that the layer
+named `data` is mapped to the CIFAR-10 images, and similarly the line
+`dataIdx=1` indicates that the layer named `labels` is mapped to the CIFAR-10
+labels.
 
-==Convolution layer==
+### Convolution layer
 
-Convolution layers apply a small set of filters all over their input "images". They're specified like this:
+Convolution layers apply a small set of filters all over their input "images".
+They're specified like this:
 
-{{{
+```ini
 [conv32]
 type=conv
 inputs=data
@@ -49,39 +56,48 @@ initW=0.00001
 initB=0.5
 sharedBiases=true
 partialSum=1
-}}}
+```
 
-Again, the bracketed *conv32* is the name we're choosing to give to this layer.
+Again, the bracketed `conv32` is the name we're choosing to give to this layer.
 
 Here's what the other parameters mean:
-|| *Parameter* || *Default value* || *Meaning* ||
-||`type=conv`||`--`||defines this as a convolution layer||
-||`inputs=data` ||`--`||says that this layer will take as input the layer named *data* (defined above) ||
-||`channels=3` ||`--`|| tells the net that the layer named *data* produces 3-channel images (i.e. color images). Since the images are assumed to be square, that is all that you have to tell it about the data dimensionality. This value must be either 1, 2, 3, or a multiple of 4.||
-|| `filters=32`||`--`|| says that this layer will apply 32 filters to the images. This number must be a multiple of 16. ||
-||`padding=4` ||`0`|| instructs the net to implicitly pad the images with a 4-pixel border of zeros (this does not cause it to create a copy of the data or use any extra memory). Set to 0 if you don't want padding.||
-||`stride=1` ||`1`||indicates that the distance between successive filter applications should be 1 pixel. ||
-||`filterSize=9` ||`--`||says that this layer will use filters of size 9x9 pixels (with 3 channels). ||
-||`neuron=logistic` ||`ident`|| defines the neuron activation function to be applied to the output of the convolution. If omitted, no function is applied. See NeuronTypes for supported types. *All layers except data and cost layers can take a neuron parameter.*||
-||`initW=0.00001` ||`0.01`|| instructs the net to initialize the weights in this layer from a normal distribution with mean zero and standard deviation 0.00001.||
-||`initB=0.5` ||`0`|| instructs the net to initialize the biases in this layer to 0.5.||
-||`sharedBiases=true` ||`true`|| indicates that the biases of every filter in this layer should be shared amongst all applications of that filter (which is how convnets are usually trained). Setting this to false will untie the biases, yielding a separate bias for every location at which the filter is applied. ||
-||`partialSum=1` ||`--`|| this is a parameter that affects the performance of the weight gradient computation. It's a bit hard to predict what value will result in the best performance (it's problem-specific), but it's worth trying a few. Valid values are ones that divide the area of the output grid in this convolutional layer. For example if this layer produces 32-channel 20x20 output grid, valid values of partialSum are ones which divide 20*20 = 400. This parameter also has an impact on memory consumption. The amount of extra memory used will be: `(number of weights in this layer)x(number of outputs this layer produces) / partialSum.` My belief is that since one of the defining features of convolutional nets is their small number of weights, this shouldn't be a big deal. ||
 
-This convolutional layer will produce 32 x _N_ x _N_ output values, where _N_ is the number of filter applications required to cover the entire width (equivalently, height) of the image plus zero-padding with the given stride. As mentioned above, each filter in this layer has 3x9x9 weights.
+| Parameter | Default value | Meaning |
+|-----------|---------------|---------|
+| `type=conv` | `--` | defines this as a convolution layer|
+| `inputs=data` | `--` | says that this layer will take as input the layer named *data* (defined above) |
+| `channels=3` | `--` | tells the net that the layer named *data* produces 3-channel images (i.e. color images). Since the images are assumed to be square, that is all that you have to tell it about the data dimensionality. This value must be either 1, 2, 3, or a multiple of 4.|
+| `filters=32` | `--` | says that this layer will apply 32 filters to the images. This number must be a multiple of 16. |
+| `padding=4` | `0` | instructs the net to implicitly pad the images with a 4-pixel border of zeros (this does not cause it to create a copy of the data or use any extra memory). Set to 0 if you don't want padding.|
+| `stride=1` | `1` | indicates that the distance between successive filter applications should be 1 pixel. |
+| `filterSize=9` | `--` | says that this layer will use filters of size 9x9 pixels (with 3 channels). |
+| `neuron=logistic` | `ident` | defines the neuron activation function to be applied to the output of the convolution. If omitted, no function is applied. See NeuronTypes for supported types. *All layers except data and cost layers can take a neuron parameter.*|
+| `initW=0.00001` | `0.01` | instructs the net to initialize the weights in this layer from a normal distribution with mean zero and standard deviation 0.00001.|
+| `initB=0.5` | `0` | instructs the net to initialize the biases in this layer to 0.5.|
+| `sharedBiases=true` | `true` | indicates that the biases of every filter in this layer should be shared amongst all applications of that filter (which is how convnets are usually trained). Setting this to false will untie the biases, yielding a separate bias for every location at which the filter is applied. |
+| `partialSum=1` | `--` | this is a parameter that affects the performance of the weight gradient computation. It's a bit hard to predict what value will result in the best performance (it's problem-specific), but it's worth trying a few. Valid values are ones that divide the area of the output grid in this convolutional layer. For example if this layer produces 32-channel 20x20 output grid, valid values of partialSum are ones which divide 20*20 = 400. This parameter also has an impact on memory consumption. The amount of extra memory used will be: `(number of weights in this layer)x(number of outputs this layer produces) / partialSum.` My belief is that since one of the defining features of convolutional nets is their small number of weights, this shouldn't be a big deal. |
+
+This convolutional layer will produce 32 x _N_ x _N_ output values, where _N_ is
+the number of filter applications required to cover the entire width
+(equivalently, height) of the image plus zero-padding with the given stride. As
+mentioned above, each filter in this layer has 3x9x9 weights.
 
 The parameters with default values may be omitted from the configuration file.
 
-===Performance notes===
-  * The computation will be most efficient when `filters` is divisible by 32.
+#### Performance notes
 
-==Locally-connected layer with unshared weights==
+* The computation will be most efficient when `filters` is divisible by 32.
 
-This kind of layer is just like a convolutional layer, but without any weight-sharing. That is to say, a different set of filters is applied at every (x, y) location in the input image. Aside from that, it behaves exactly as a convolutional layer.
+### Locally-connected layer with unshared weights
 
-Here's how to define such a layer, taking the *conv32* layer as input:
+This kind of layer is just like a convolutional layer, but without any
+weight-sharing. That is to say, a different set of filters is applied at every
+(x, y) location in the input image. Aside from that, it behaves exactly as a
+convolutional layer.
 
-{{{
+Here's how to define such a layer, taking the `conv32` layer as input:
+
+```ini
 [local32]
 type=local
 inputs=conv32
@@ -93,33 +109,36 @@ filterSize=9
 neuron=logistic
 initW=0.00001
 initB=0
-}}}
+```
 
 Aside from the *type=local* line, there's nothing new here. Note however that since there is no weight sharing, the actual number of distinct filters in this layer will be `filters` multiplied by however many filter applications are required to cover the entire image and padding with the given stride.
 
-===Performance notes===
-  * The computation will be most efficient when `filters` is divisible by 32.
+#### Performance notes
 
-==Fully-connected layer==
+* The computation will be most efficient when `filters` is divisible by 32.
 
-A fully-connected layer simply multiplies its input by a weight matrix. It's specified like this:
+### Fully-connected layer
 
-{{{
+A fully-connected layer simply multiplies its input by a weight matrix. It's
+specified like this:
+
+```ini
 [fc1024]
 type=fc
 outputs=1024
 inputs=data
 initW=0.001
 neuron=relu
-}}}
+```
 
-The only parameter here that we have not yet seen is *outputs=1024*. It does what you would expect -- it indicates that this layer should have 1024 neurons.
+The only parameter here that we have not yet seen is `outputs=1024`. It does
+what you would expect -- it indicates that this layer should have 1024 neurons.
 
-==Local pooling layer==
+### Local pooling layer
 
 This type of layer performs local, *per-channel* pooling on its input.
 
-{{{
+```ini
 [maxpool]
 type=pool
 pool=max
@@ -130,78 +149,98 @@ stride=2
 outputsX=0
 channels=32
 neuron=relu
-}}}
+```
 
 A few new parameters here:
-|| *Parameter* || *Default value* || *Meaning* ||
-||`pool=max` ||`--`||indicates that this is to be a max-pooling layer. Also supported is *pool=avg* for average-pooling. ||
-||`inputs=conv32` ||`--`||indicates that this layer subsamples the layer named *conv32*.||
-||`start=0` ||`0`||tells the net where in the input image to start the pooling (in x,y coordinates). In principle, you can start anywhere you want. Setting this to a positive number will cause the net to discard some pixels at the top and at the left of the image. Setting this to a negative number will cause it to include pixels that don't exist (which is fine). *start=0* is the usual setting. ||
-||`sizeX=4` ||`--`||defines the size of the pooling region in the x (equivalently, y) dimension. Squares of size (*sizeX*)^2^ get reduced to one value by this layer. There are no restrictions on the value of this parameter. It's fine for a pooling square to fall off the boundary of the image.||
-||`stride=2` ||`--`||defines the stride size between successive pooling squares. Setting this parameter smaller than *sizeX* produces _overlapping_ pools. Setting it equal to *sizeX* gives the usual, non-overlapping pools. Values greater than *sizeX* are not allowed. ||
-||`outputsX=0` ||`0`||allows you to control how many output values in the x (equivalently, y) dimension this operation will produce. This parameter is analogous to the *start* parameter, in that it allows you to discard some portion of the image by setting it to a value small enough to leave part of the image uncovered. Setting it to zero instructs the net to produce as many outputs as is necessary to ensure that the whole image is covered. ||
+
+| Parameter | Default value | Meaning |
+|-----------|---------------|---------|
+| `pool=max` | `--` | indicates that this is to be a max-pooling layer. Also supported is *pool=avg* for average-pooling. |
+| `inputs=conv32` | `--` | indicates that this layer subsamples the layer named *conv32*.|
+| `start=0` | `0` | tells the net where in the input image to start the pooling (in x,y coordinates). In principle, you can start anywhere you want. Setting this to a positive number will cause the net to discard some pixels at the top and at the left of the image. Setting this to a negative number will cause it to include pixels that don't exist (which is fine). *start=0* is the usual setting. |
+| `sizeX=4` | `--` | defines the size of the pooling region in the x (equivalently, y) dimension. Squares of size (*sizeX*)<sup>2</sup> get reduced to one value by this layer. There are no restrictions on the value of this parameter. It's fine for a pooling square to fall off the boundary of the image.|
+| `stride=2` | `--` | defines the stride size between successive pooling squares. Setting this parameter smaller than *sizeX* produces _overlapping_ pools. Setting it equal to *sizeX* gives the usual, non-overlapping pools. Values greater than *sizeX* are not allowed. |
+| `outputsX=0` | `0` | allows you to control how many output values in the x (equivalently, y) dimension this operation will produce. This parameter is analogous to the *start* parameter, in that it allows you to discard some portion of the image by setting it to a value small enough to leave part of the image uncovered. Setting it to zero instructs the net to produce as many outputs as is necessary to ensure that the whole image is covered. |
 
 Since the pooling performed by this layer is per-channel, the number of output channels is equivalent to the number of input channels. But the size of the image in the x,y dimensions gets reduced.
 
-==Local response normalization layer (same map)==
+### Local response normalization layer (same map)
 
 This kind of layer computes the function
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/rnorm.gif
+![Local response normalization](images/rnorm.gif)
 
-where http://cuda-convnet.googlecode.com/svn/wiki/images/u_fxy.gif is the activity of a unit in map _f_ at position _x,y_ prior to normalization, _S_ is the image size, and _N_ is the size of the region to use for normalization. The output dimensionality of this layer is always equal to the input dimensionality.
+where ![](images/u_fxy.gif) is the activity of a unit in map _f_ at position
+_x,y_ prior to normalization, _S_ is the image size, and _N_ is the size of the
+region to use for normalization. The output dimensionality of this layer is
+always equal to the input dimensionality.
 
-This type of layer turns out to be useful when using neurons with unbounded activations (e.g. rectified linear neurons), because it permits the detection of high-frequency features with a big neuron response, while damping responses that are uniformly large in a local neighborhood. It is a type of regularizer that encourages "competition" for big activities among nearby groups of neurons.
+This type of layer turns out to be useful when using neurons with unbounded
+activations (e.g. rectified linear neurons), because it permits the detection of
+high-frequency features with a big neuron response, while damping responses that
+are uniformly large in a local neighborhood. It is a type of regularizer that
+encourages "competition" for big activities among nearby groups of neurons.
 
 Here's how this layer is specified:
 
-{{{
+```ini
 [rnorm1]
 type=rnorm
 inputs=maxpool
 channels=32
 size=5
-}}}
+```
 
-|| *Parameter* || *Meaning* ||
-|| `channels=32` || indicates that this layer takes 32-channel input because that's what the *maxpool* layer produces. The number of "channels" here just serves to define the shape of the input and has no actual bearing on the output (unlike in convolutional layers, which sum over channels). ||
-|| `size=5` || the _N_ variable in the above formula, this defines the size of the local regions used for response normalization. Squares of (*size*)^2^ are used to normalize each pixel. The squares are centered at the pixel. ||
+| Parameter | Meaning |
+|-----------|---------|
+| `channels=32` | indicates that this layer takes 32-channel input because that's what the *maxpool* layer produces. The number of "channels" here just serves to define the shape of the input and has no actual bearing on the output (unlike in convolutional layers, which sum over channels). |
+| `size=5` | the _N_ variable in the above formula, this defines the size of the local regions used for response normalization. Squares of (*size*)<sup>2</sup> are used to normalize each pixel. The squares are centered at the pixel. |
 
-The _alpha_ and _beta_ variables are specified in the [LayerParams#Local_response/contrast_normalization_layers layer parameter file], so that you can change them during training.
+The _alpha_ and _beta_ variables are specified in the [layer parameter file](#local-responsecontrast-normalization-layers), so that you can change them during training.
 
-==Local response normalization layer (across maps)==
+### Local response normalization layer (across maps)
 
-This layer is just like the one described above, but units are divided only by the activities of other units *in the same position but in different maps (channels)*.
+This layer is just like the one described above, but units are divided only by
+the activities of other units *in the same position but in different maps
+(channels)*.
 
 It's specified like this:
 
-{{{
+```ini
 [rnorm2]
 type=cmrnorm
 inputs=maxpool
 channels=32
 size=5
-}}}
+```
 
-The *size* parameter indicates how many nearby maps to use for normalization. For example, if your layer has 32 maps, a unit in the 7th map will be normalized by units in the 5th through 9th maps when *size* is set to 5.
+The *size* parameter indicates how many nearby maps to use for normalization.
+For example, if your layer has 32 maps, a unit in the 7th map will be normalized
+by units in the 5th through 9th maps when *size* is set to 5.
 
 Specifically, the function that this layer computes is:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/rnorm-crossmap.gif
+![response normalization cross map](images/rnorm-crossmap.gif)
 
-Here _F_ is the number of maps. The _alpha_ and _beta_ parameters are specified in the layer parameter file, described here: [LayerParams#Layer_parameter_file_-_basic_features]
+Here _F_ is the number of maps. The _alpha_ and _beta_ parameters are specified
+in the layer parameter file, described
+[here](#layer-parameter-file---basic-features).
 
-==Local contrast normalization layer==
+### Local contrast normalization layer
 
 This kind of layer computes the function
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/cnorm.gif
+![local contrast normalization](images/cnorm.gif)
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/m_fxy.gif here is the mean of all http://cuda-convnet.googlecode.com/svn/wiki/images/u_fxy.gif in the 2D neighbourhood defined by the above summation bounds. This layer is very similar computationally to response normalization -- the difference being that the denominator here computes the variance of activities in each neighborhood, rather than just the sum of squares (correlation).
+![](m_fxy.gif) here is the mean of all ![](u_fxy.gif) in the 2D neighbourhood
+defined by the above summation bounds. This layer is very similar
+computationally to response normalization -- the difference being that the
+denominator here computes the variance of activities in each neighborhood,
+rather than just the sum of squares (correlation).
 
 Here's how this layer is specified:
 
-{{{
+```ini
 [cnorm1]
 type=cnorm
 inputs=rnorm1
@@ -209,68 +248,78 @@ channels=32
 sizeX=7
 scale=0.001
 pow=0.5
-}}}
+```
 
-The meanings of all of these parameters are the same as in the response normalization layer described above.
+The meanings of all of these parameters are the same as in the response
+normalization layer described above.
 
-==Neuron layer==
+### Neuron layer
 
-This layer takes one layer as input and applies a neuron activation function to it. See NeuronTypes for available activation functions.
+This layer takes one layer as input and applies a neuron activation function to
+it. See NeuronTypes for available activation functions.
 
 This layer is specified like this:
 
-{{{
+```ini
 [neuron1]
 type=neuron
 inputs=layer1
 neuron=logistic
-}}}
+```
 
-Note that all layers except data layers and cost layers can take a *neuron=x* parameter, so there is often no need to explicitly define these neuron layers.
+Note that all layers except data layers and cost layers can take a *neuron=x*
+parameter, so there is often no need to explicitly define these neuron layers.
 
-Side-note: this layer is admittedly misnamed. It just applies an element-wise function to its input. So don't think of neurons with weights. This layer has no weights.
+Side-note: this layer is admittedly misnamed. It just applies an element-wise
+function to its input. So don't think of neurons with weights. This layer has no
+weights.
 
-==Elementwise sum layer==
+### Elementwise sum layer
 
-This kind of layer simply performs an elementwise weighted sum of its input layers. Of course this implies that all of its input layers must have the same dimensionality. It's specified like this:
+This kind of layer simply performs an elementwise weighted sum of its input
+layers. Of course this implies that all of its input layers must have the same
+dimensionality. It's specified like this:
 
-{{{
+```ini
 [sumlayer]
 type=eltsum
 inputs=layer1,layer2,layer3
 coeffs=0.5,-1,1.2
-}}}
+```
 
-This layer will produce the weighted sum 0.5 x *layer1* - *layer2* + 1.2 x *layer3*.
+This layer will produce the weighted sum 0.5 x `layer1` - `layer2` + 1.2 x `layer3`.
 
-|| *Parameter* || *Default value* || *Meaning* ||
-||`coeffs=0.5,-1,1.2` ||`1,...`||the coefficients of summation for the specified inputs.||
+| Parameter | Default value | Meaning |
+|-----------|---------------|---------|
+| `coeffs=0.5,-1,1.2` | `1,...` | The coefficients of summation for the specified inputs. |
 
-The number of output values in this layer is of course equal to the number of output values in any of the input layers.
+The number of output values in this layer is of course equal to the number of
+output values in any of the input layers.
 
-==Elementwise max layer==
+### Elementwise max layer
 
 This kind of layer performs an elementwise max of its input layers.
 
 It is specified like this:
 
-{{{
+```ini
 [maxlayer]
 type=eltmax
 inputs=layer1,layer2,layer3
-}}}
+```
 
-This will produce an output matrix in which every element at position (_i_,_j_) is the max of the (_i_,_j_)th elements of *layer1*, *layer2*, and *layer3*.
+This will produce an output matrix in which every element at position $(i, j)$
+is the max of the $(i, j)$ elements of `layer1`, `layer2`, and `layer3`.
 
-==Softmax layer==
+### Softmax layer
 
 This layer computes the function
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/softmax.gif
+![softmax](images/softmax.gif)
 
-where each _x,,i,,_ is an input value. It's specified like this:
+where each $x_i$ is an input value. It's specified like this:
 
-{{{
+```ini
 [fc10]
 type=fc
 outputs=10
@@ -280,27 +329,37 @@ initW=0.0001
 [probs]
 type=softmax
 inputs=fc10
-}}}
+```
 
-Here we're really defining two layers -- *fc10* is a fully-connected layer with 10 output values (because our dataset has 10 classes), and *probs* is a softmax that takes *fc10* as input and produces 10 values which can be interpreted as probabilities. This type of layer is useful for classification tasks.
+Here we're really defining two layers -- `fc10` is a fully-connected layer with
+10 output values (because our dataset has 10 classes), and `probs` is a softmax
+that takes `fc10` as input and produces 10 values which can be interpreted as
+probabilities. This type of layer is useful for classification tasks.
 
-==Logistic regression cost layer==
+### Logistic regression cost layer
 
-A net must define an objective function to optimize. Here we're defining a (multinomial) [http://en.wikipedia.org/wiki/Multinomial_logistic_regression logistic regression] objective. It's specified like this:
+A net must define an objective function to optimize. Here we're defining a
+(multinomial) [logistic
+regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression)
+objective. It's specified like this:
 
-{{{
+```ini
 [logprob]
 type=cost.logreg
 inputs=labels,probs
-}}}
+```
 
-The *cost.logreg* objective takes two inputs -- true labels and predicted probabilities. We defined the *labels* layer early on, and the *probs* layer just above.
+The `cost.logreg` objective takes two inputs -- true labels and predicted
+probabilities. We defined the `labels` layer early on, and the `probs` layer
+just above.
 
-==Sum-of-squares cost layer==
+### Sum-of-squares cost layer
 
-This objective minimizes the squared L2 norm of the layer below. One use for it is to train autoencoders. For example, you can minimize reconstruction error like this:
+This objective minimizes the squared L2 norm of the layer below. One use for it
+is to train autoencoders. For example, you can minimize reconstruction error
+like this:
 
-{{{
+```ini
 [diff]
 inputs=recon,data
 type=eltsum
@@ -309,194 +368,251 @@ coeffs=1,-1
 [sqdiff]
 type=cost.sum2
 inputs=diff
-}}}
+```
 
-This defines two layers -- the first subtracts the "data" from the "reconstruction" and the second is the sum-of-squares cost layer which minimizes the sum of the squares of its input.
+This defines two layers -- the first subtracts the "data" from the
+"reconstruction" and the second is the sum-of-squares cost layer which minimizes
+the sum of the squares of its input.
 
-=Layer definition file - data manipulation layers =
+## Layer definition file - data manipulation layers
 
-Data manipulation layers pre-process the data in some way. Normal use cases do not involve propagating gradient through them, and some of them do not support gradient propagation.
+Data manipulation layers pre-process the data in some way. Normal use cases do
+not involve propagating gradient through them, and some of them do not support
+gradient propagation.
 
-==Gaussian blur layer==
+### Gaussian blur layer
 
-This kind of layer is useful if you're interested in multi-scale learning. Many vision systems learn (or simply apply) features at multiple scales. To do that, it's good to be able to subsample the input images in a way that doesn't introduce a lot of aliasing. Blurring them achieves that.
+This kind of layer is useful if you're interested in multi-scale learning. Many
+vision systems learn (or simply apply) features at multiple scales. To do that,
+it's good to be able to subsample the input images in a way that doesn't
+introduce a lot of aliasing. Blurring them achieves that.
 
-So here's how you specify a [http://en.wikipedia.org/wiki/Gaussian_blur Gaussian blur] layer:
+So here's how you specify a [Gaussian
+blur](https://en.wikipedia.org/wiki/Gaussian_blur) layer:
 
-{{{
+```ini
 [myblur]
 type=blur
 inputs=data
 filterSize=5
 stdev=2
 channels=3
-}}}
+```
 
 The non-obvious parameters are:
 
-|| *Parameter* || *Default value* || *Meaning* ||
-||`filterSize=5` ||`--`||the width (in pixels) of the Gaussian blur filter to apply to the image. This must be one of 3, 5, 7, or 9.||
-||`stdev=1` ||`--`||the standard deviation of the Gaussian. This can be any positive float.||
+| Parameter | Default value | Meaning |
+|-----------|---------------|---------|
+| `filterSize=5` | `--` | the width (in pixels) of the Gaussian blur filter to apply to the image. This must be one of 3, 5, 7, or 9.|
+| `stdev=1` | `--` | the standard deviation of the Gaussian. This can be any positive float.|
 
 The number of output values in this layer is equal to the number of input values.
 
-The layer defined above will convolve its input layer *data* with the following 1-D filter (both horizontally and vertically, of course):
-{{{
+The layer defined above will convolve its input layer *data* with the following
+1-D filter (both horizontally and vertically, of course):
+
+```
 [0.05448869,  0.24420136,  0.40261996,  0.24420136,  0.05448869]
-}}}
+```
 
-Note that no matter what parameters you specify, the sum of all elements in the filter will always be 1. Intuitively, wider Gaussians (i.e. bigger standard deviations) require an increase in the `filterSize` parameter.
+Note that no matter what parameters you specify, the sum of all elements in the
+filter will always be 1. Intuitively, wider Gaussians (i.e. bigger standard
+deviations) require an increase in the `filterSize` parameter.
 
-==Bed of nails layer==
+### Bed of nails layer
 
-This layer applies a [http://en.wikipedia.org/wiki/Shah_function Dirac comb] to the input image. Use this layer to subsample a Gaussian-blurred image.
+This layer applies a [Dirac comb](https://en.wikipedia.org/wiki/Shah_function) to
+the input image. Use this layer to subsample a Gaussian-blurred image.
 
 It's specified like this:
 
-{{{
+```ini
 [mynails]
 type=nailbed
 inputs=myblur
 stride=2
 channels=3
-}}}
+```
 
-The only new parameter here is `stride`, which indicates the spacing (in pixels) between samples. With a stride of 2, every other pixel is skipped, so the output image will be roughly 4 times smaller in area.
+The only new parameter here is `stride`, which indicates the spacing (in pixels)
+between samples. With a stride of 2, every other pixel is skipped, so the output
+image will be roughly 4 times smaller in area.
 
-==Image resizing layer==
+### Image resizing layer
 
-Gaussian blur + bed-of-nails subsampling can reduce your image size by an integer factor, but you might also want to resize your images by a smaller amount. This layer implements image resizing with [http://en.wikipedia.org/wiki/Bilinear_filtering bilinear filtering]. It can cleanly (i.e. without aliasing) resize images by a factors roughly within the range 0.5-2.
+Gaussian blur + bed-of-nails subsampling can reduce your image size by an
+integer factor, but you might also want to resize your images by a smaller
+amount. This layer implements image resizing with [bilinear
+filtering](https://en.wikipedia.org/wiki/Bilinear_filtering). It can cleanly
+(i.e. without aliasing) resize images by a factors roughly within the range
+0.5-2.
 
 It's specified like this:
 
-{{{
+```ini
 [resiz]
 type=resize
 inputs=data
 scale=1.3
 channels=3
-}}}
+```
 
-This will scale the input images _down_ by a factor of 1.3. So if your input consisted of 32x32 images, the output of this layer will have dimensions 24x24 (it rounds down from 32/1.3 = 24.6).
+This will scale the input images _down_ by a factor of 1.3. So if your input
+consisted of 32x32 images, the output of this layer will have dimensions 24x24
+(it rounds down from 32/1.3 = 24.6).
 
-*Note*: This layer cannot propagate gradient. So it should only be placed over layers that do not need to compute the gradient (e.g. the data layer).
+*Note*: This layer cannot propagate gradient. So it should only be placed over
+layers that do not need to compute the gradient (e.g. the data layer).
 
-== Color space manipulation layers ==
+### Color space manipulation layers
 
 These layers convert between color spaces. Note that they cannot propagate gradient, and as such must not be placed over any layers with weights if you expect to learn those weights.
 
-=== RGB to YUV layer ===
+#### RGB to YUV layer
 
 This layer converts RGB-coded images to YUV-coded images.
 
 Specifically, it applies the following linear transformation to the color channels of the input:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/rgb_to_yuv.png
+![RGB to YUV](images/rgb_to_yuv.png)
 
 This layer is specified like this:
 
-{{{
+```ini
 [yuv]
 type=rgb2yuv
 inputs=data
-}}}
+```
 
-=== RGB to L`*`a`*`b`*` layer ===
+#### RGB to $L^{\ast} a^{\ast} b^{\ast}$ layer
 
-This layer converts RGB-coded images to L`*`a`*`b`*`-coded images.
+This layer converts RGB-coded images to $L^{\ast} a^{\ast} b^{\ast}$ coded images.
 
 Specifically, it applies the two transformations described on these Wikipedia pages:
-  # http://en.wikipedia.org/wiki/CIE_1931_color_space#Construction_of_the_CIE_XYZ_color_space_from_the_Wright.E2.80.93Guild_data
-  # http://en.wikipedia.org/wiki/Lab_color_space#The_forward_transformation
+
+* https://en.wikipedia.org/wiki/CIE_1931_color_space#Construction_of_the_CIE_XYZ_color_space_from_the_Wright.E2.80.93Guild_data
+* https://en.wikipedia.org/wiki/Lab_color_space#The_forward_transformation
 
 I'll reproduce the transformation here. Assuming the input RGB values  are in the range 0-1:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/rgb_to_xyz.gif
+![RGB to XYZ](images/rgb_to_xyz.gif)
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/xyz_to_lab.gif
+![XYZ to Lab](images/xyz_to_lab.gif)
 
 where
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/f_lab.png
+![f(t) for Lab](images/f_lab.png)
 
-*Note that an underlying assumption in this layer is that its input is in the range 0-1. This assumption is violated by the default CIFAR-10 data provider, which produces zero-mean data.*
+*Note that an underlying assumption in this layer is that its input is in the
+range 0-1. This assumption is violated by the default CIFAR-10 data provider,
+which produces zero-mean data.*
 
 This layer is specified like this:
 
-{{{
+```ini
 [lab]
 type=rgb2lab
 inputs=data
 center=true
-}}}
+```
 
-When *center* is true, 50 will be subtracted from the final value of L`*`. Otherwise, L`*` will be left as given by the formulas above. (Note that the range of L`*` in the above formulas is 0-100, while the ranges of a`*` and b`*` are centered at 0).
+When `center` is true, 50 will be subtracted from the final value of $L^{\ast}$.
+Otherwise, $L^{\ast}$ will be left as given by the formulas above. (Note that the
+range of $L^{\ast}$ in the above formulas is 0-100, while the ranges of $a^{\ast}$ and
+$b^{\ast}$ are centered at 0).
 
-= Layer parameter file - basic features =
+## Layer parameter file - basic features
 
-In this file you can specify learning parameters that you may want to change during the course of training (learning rates, etc.). You can find examples of this kind of file [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/ here].
+In this file you can specify learning parameters that you may want to change
+during the course of training (learning rates, etc.). You can find examples of
+this kind of file in [`../example-layers`](../example-layers).
 
-The idea is that you'll use one file to define the net's architecture, which stays fixed for the duration of training, and another file to define learning parameters, which you can change while the net is training.
+The idea is that you'll use one file to define the net's architecture, which
+stays fixed for the duration of training, and another file to define learning
+parameters, which you can change while the net is training.
 
-I'll now go through the learning parameters that the above-defined layers take. Generally, only layers with weights require learning parameters.
+I'll now go through the learning parameters that the above-defined layers take.
+Generally, only layers with weights require learning parameters.
 
-==Layers with weights==
+### Layers with weights
 
-Here's how to specify learning parameters for layers with weights (convolutional layers, locally-connected layers, and fully-connected layers).
+Here's how to specify learning parameters for layers with weights (convolutional
+layers, locally-connected layers, and fully-connected layers).
 
-{{{
+```ini
 [conv32]
 epsW=0.001
 epsB=0.002
 momW=0.9
 momB=0.9
 wc=0
-}}}
+```
 
-This specifies the learning parameters for the layer *conv32*. Here's what the parameters mean:
-|| *Parameter* || *Meaning* ||
-||epsW=0.001 ||the weight learning rate. ||
-||epsB=0.002 ||the bias learning rate. ||
-||momW=0.9||the weight momentum. ||
-||momB=0.9||the bias momentum. ||
-||wc=0 || the L2 weight decay (applied to the weights but not the biases).||
+This specifies the learning parameters for the layer `conv32`. Here's what the
+parameters mean:
+
+| Parameter | Meaning |
+|-----------|---------|
+| epsW=0.001 | the weight learning rate. |
+| epsB=0.002 | the bias learning rate. |
+| momW=0.9 | the weight momentum. |
+| momB=0.9 | the bias momentum. |
+| wc=0 | the L2 weight decay (applied to the weights but not the biases).|
 
 Given these values, the update rule for the weights is:
-{{{
+
+```
 weight_inc[i] := momW * weight_inc[i-1] - wc * epsW * weights[i-1] + epsW * weight_grads[i]
 weights[i] := weights[i-1] + weight_inc[i]
-}}}
+```
 
-where `weight_grads[i]` is the average gradient over minibatch `i`. The update rule for biases is the same except that there is no bias weight decay.
+where `weight_grads[i]` is the average gradient over minibatch `i`. The update
+rule for biases is the same except that there is no bias weight decay.
 
-If you want to not learn the weights in a particular layer (perhaps because you've [LayerParams#Initializing_weights_from_an_outside_source initialized them in some awesome way]), you can set its `epsW` and `epsB` parameters to 0, and then that layer won't be learned. The net will run faster as a result.
+If you want to not learn the weights in a particular layer (perhaps because
+you've [initialized them in some awesome
+way](#initializing-weights-from-an-outside-source)), you can set
+its `epsW` and `epsB` parameters to 0, and then that layer won't be learned. The
+net will run faster as a result.
 
-==Cost layers==
+### Cost layers
 
-Cost layers, such as the *logprob* and *sqdiff* layers defined above, take one parameter:
-{{{
+Cost layers, such as the `logprob` and `sqdiff` layers defined above, take one
+parameter:
+
+```ini
 [logprob]
 coeff=1
-}}}
+```
 
-... a scalar coefficient of the objective function. This provides an easy way to tweak the "global" learning rate of the network. Note, however, that tweaking this parameter is not equivalent to tweaking the *epsW* parameter of every layer in the net if you use weight decay. That's because tweaking *coeff* will leave the effective weight decay coefficient (`epsW*wc`) unchanged. But tweaking *epsW* will of course cause a change in `epsW*wc`.
+... a scalar coefficient of the objective function. This provides an easy way to
+tweak the "global" learning rate of the network. Note, however, that tweaking
+this parameter is not equivalent to tweaking the `epsW` parameter of every layer
+in the net if you use weight decay. That's because tweaking `coeff` will leave
+the effective weight decay coefficient (`epsW * wc`) unchanged. But tweaking
+`epsW` will of course cause a change in `epsW * wc`.
 
-==Local response/contrast normalization layers==
-The *rnorm*, *cnorm*, and *cmrnorm* layer types two parameters:
+### Local response/contrast normalization layers
 
-{{{
+The `rnorm`, `cnorm`, and `cmrnorm` layer types two parameters:
+
+```ini
 scale=0.0000125
 pow=0.75
-}}}
+```
 
-These are the _alpha_ and _beta_, respectively, in the equations in [LayerParams#Local_response_normalization_layer_(same_map)] and the two section following it.
+These are the _alpha_ and _beta_, respectively, in the equations in [local
+response normalization layer](#local-response-normalization-layer-same-map) and
+the two section following it.
 
-= Layer definition file  - slightly more advanced features =
-== Block sparse convolution layer ==
+## Layer definition file  - slightly more advanced features
 
-This is a convolutional layer in which each filter only looks at _some_ of the input channels.
+### Block sparse convolution layer
 
-{{{
+This is a convolutional layer in which each filter only looks at _some_ of the
+input channels.
+
+```ini
 [conv32-2]
 type=conv
 inputs=cnorm1
@@ -510,27 +626,38 @@ neuron=relu
 initW=0.0001
 partialSum=1
 sharedBiases=false
-}}}
+```
 
-The primary novelty here is the *groups=4* parameter. Together with the *filters=32* parameter, they state that this convolutional layer is to have 4 groups of 32 filters. Each filter will connect to (i.e. sum over) 8 input channels (a quarter of the total number of input channels).
+The primary novelty here is the `groups=4` parameter. Together with the
+`filters=32` parameter, they state that this convolutional layer is to have 4
+groups of 32 filters. Each filter will connect to (i.e. sum over) 8 input
+channels (a quarter of the total number of input channels).
 
-The following diagram depicts the kind of operation that this layer will perform (note however that the diagram depicts two filters per group rather than 32).
+The following diagram depicts the kind of operation that this layer will perform
+(note however that the diagram depicts two filters per group rather than 32).
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/conv-diagram.png
+![convolution diagram](images/conv-diagram.png)
 
-*Block sparsity may be used in convolutional layers as well as in locally-connected, unshared layers. Simply replace type=conv with type=local to do this in locally-connected, unshared layers.*
+*Block sparsity may be used in convolutional layers as well as in
+locally-connected, unshared layers. Simply replace `type=conv` with `type=local`
+to do this in locally-connected, unshared layers.*
 
-===Performance notes===
-  * Block sparse convolutional layers are just as efficient computationally as non-sparse convolutional layers.
-  * The computation will be most efficient when `channels / groups` is divisible by 16 and `filters` is divisible by 32.
+#### Performance notes
 
-== Random sparse convolution layer ==
+* Block sparse convolutional layers are just as efficient computationally as
+  non-sparse convolutional layers.
+* The computation will be most efficient when `channels / groups` is divisible
+  by 16 and `filters` is divisible by 32.
 
-A random sparse convolution layer is similar to the block sparse convolution layer described above, but here each group of filters connects to a _random_ subset of channels in the layer below.
+### Random sparse convolution layer
+
+A random sparse convolution layer is similar to the block sparse convolution
+layer described above, but here each group of filters connects to a _random_
+subset of channels in the layer below.
 
 Here's how this kind of layer is specified:
 
-{{{
+```ini
 [conv32-3]
 type=conv
 inputs=conv32-2
@@ -545,28 +672,46 @@ initW=0.0001
 partialSum=1
 randSparse=true
 filterChannels=64
-}}}
+```
 
-Notice that this layer has 128-channel input, because its input layer, *conv32-2*, has 128 (4 groups of 32) filters. This layer will produce 64-channel output, since it has 2 groups of 32 filters.
+Notice that this layer has 128-channel input, because its input layer,
+`conv32-2`, has 128 (4 groups of 32) filters. This layer will produce 64-channel
+output, since it has 2 groups of 32 filters.
 
 There are two new parameters here:
 
-|| *Parameter* || *Default value* || *Meaning* ||
-||`randSparse=true` ||`false`|| indicates that random sparsity should be used in this layer. When this parameter is true, the `groups` parameter must be greater than 1 (otherwise the connectivity will not be sparse). ||
-||`filterChannels=64` ||`channels/groups`||an optional parameter indicating how many input channels each filter should look at. The quantity `filterChannels*groups` must be a multiple of `channels`.||
+| Parameter | Default value | Meaning |
+|-----------|---------------|---------|
+| `randSparse=true` | `false` | indicates that random sparsity should be used in this layer. When this parameter is true, the `groups` parameter must be greater than 1 (otherwise the connectivity will not be sparse). |
+| `filterChannels=64` | `channels/groups` | an optional parameter indicating how many input channels each filter should look at. The quantity `filterChannels*groups` must be a multiple of `channels`.|
 
-*Random sparsity may be used in convolutional layers as well as in locally-connected unshared layers.* For locally-connected unshared layers, each group of *filters* filters at _all locations_ will connect to the same random subset of input channels. So in all there will still be *groups* random subsets, just like in a convolutional layer.
+*Random sparsity may be used in convolutional layers as well as in
+locally-connected unshared layers.* For locally-connected unshared layers, each
+group of *filters* filters at _all locations_ will connect to the same random
+subset of input channels. So in all there will still be *groups* random subsets,
+just like in a convolutional layer.
 
-===Performance notes===
-  * Random sparse convolutional layers are only about 1% less efficient computationally than block sparse convolutional layers, which themselves are as efficient as non-sparse convolutional layers. So there's no performance reason to avoid them.
-  * The computation will be most efficient when `filterChannels` is divisible by 16 and `filters` is divisible by 32.
+#### Performance notes
 
-==Layers with multiple inputs==
+* Random sparse convolutional layers are only about 1% less efficient
+  computationally than block sparse convolutional layers, which themselves are
+  as efficient as non-sparse convolutional layers. So there's no performance
+  reason to avoid them.
+* The computation will be most efficient when `filterChannels` is divisible by
+  16 and `filters` is divisible by 32.
 
-All of the layers with weights (convolutional, locally-connected, and fully-connected) can take multiple layers as input. When there are multiple input layers, a separate set of weights (filters, if you like) is used for each input. Each input/weight pair produces some output, and the final output of the layer is the summation of all those outputs. This implies that all input/weight pairs must produce output of equivalent dimensions.
+### Layers with multiple inputs
+
+All of the layers with weights (convolutional, locally-connected, and
+fully-connected) can take multiple layers as input. When there are multiple
+input layers, a separate set of weights (filters, if you like) is used for each
+input. Each input/weight pair produces some output, and the final output of the
+layer is the summation of all those outputs. This implies that all input/weight
+pairs must produce output of equivalent dimensions.
 
 For example, you can write a convolutional layer with two input layers like this:
-{{{
+
+```ini
 [conv5b]
 type=conv
 inputs=conv4b,conv5
@@ -580,100 +725,139 @@ initB=1
 partialSum=13
 groups=1,1
 sharedBiases=true
-}}}
+```
 
-This convolutional layer takes the two layers *conv4b* and *conv5* as input. Since there are two sets of weights in this layer, you must specify two values for most of the parameters which define the operation that those weights perform on their respective inputs. Some of the parameters remain unary, for example the *initB* parameter, since there is still only one bias vector for all the outputs.
+This convolutional layer takes the two layers `conv4b` and `conv5` as input.
+Since there are two sets of weights in this layer, you must specify two values
+for most of the parameters which define the operation that those weights perform
+on their respective inputs. Some of the parameters remain unary, for example the
+`initB` parameter, since there is still only one bias vector for all the
+outputs.
 
-As mentioned above, you must choose sets of parameters that lead to convolutions which produce equivalently-sized output vectors.
+As mentioned above, you must choose sets of parameters that lead to convolutions
+which produce equivalently-sized output vectors.
 
-A locally-connected, unshared layer with multiple inputs can be specified in exactly the same way, replacing *type=conv* with *type=local*.
+A locally-connected, unshared layer with multiple inputs can be specified in
+exactly the same way, replacing `type=conv` with `type=local`.
 
 A fully-connected layer with multiple inputs can be specified like this:
 
-{{{
+```ini
 [fc1000]
 type=fc
 outputs=1000
 inputs=pool3,probs
 initW=0.001,0.1
-}}}
+```
 
-In a fully-connected layer, you don't have to do anything to make the number of output values in the two computations equivalent. The number of output values is defined by the *outputs* parameter.
+In a fully-connected layer, you don't have to do anything to make the number of
+output values in the two computations equivalent. The number of output values is
+defined by the `outputs` parameter.
 
-==Weight sharing between layers==
+### Weight sharing between layers
 
-Layers may share their weights with other layers of the same kind. One of the things this allows you to do is to write recurrent networks. For example, a layer may take as input the output of another layer which uses *the same weights* -- so in effect the layer is taking its own output (in a previous "time step") as input.
+Layers may share their weights with other layers of the same kind. One of the
+things this allows you to do is to write recurrent networks. For example, a
+layer may take as input the output of another layer which uses *the same
+weights* -- so in effect, the layer is taking its own output (in a previous
+"time step") as input.
 
-All layers with weights (convolutional, locally-connected, and fully-connected) can share weights. To specify that a layer should use the weight matrix from another layer, add the *weightSource* parameter to the layer's definition file.
+All layers with weights (convolutional, locally-connected, and fully-connected)
+can share weights. To specify that a layer should use the weight matrix from
+another layer, add the `weightSource` parameter to the layer's definition file.
 
 Here's an example:
 
-{{{
+```ini
 [conv7]
 type=conv
 inputs=conv5
 ...
 weightSource=conv6
-}}}
+```
 
-This says that the layer *conv7* will use the same weight matrix as *conv6*. Of course this requires that the weight matrix of *conv6* have the same shape as the weight matrix that *conv7* would have had without sharing.
+This says that the layer `conv7` will use the same weight matrix as `conv6`. Of
+course this requires that the weight matrix of `conv6` have the same shape as
+the weight matrix that `conv7` would have had without sharing.
 
-Note also that the momentum and weight decay parameters given for *conv7* in the layer parameter file will be ignored. Only layers which own their weight matrix apply momentum and weight decay. Additionally, the *initW* parameter will also be ignored, for obvious reasons.
+Note also that the momentum and weight decay parameters given for `conv7` in the
+layer parameter file will be ignored. Only layers which own their weight matrix
+apply momentum and weight decay. Additionally, the `initW` parameter will also
+be ignored, for obvious reasons.
 
-Now suppose *conv6* has multiple weight matrices (as it would if it took multiple inputs). If you want *conv7* to share its weight matrix with the *third* weight matrix of *conv6*, you can do it like this:
+Now suppose `conv6` has multiple weight matrices (as it would if it took
+multiple inputs). If you want `conv7` to share its weight matrix with the
+`third` weight matrix of `conv6`, you can do it like this:
 
-{{{
+```ini
 [conv7]
 type=conv
 inputs=conv5
 ...
 weightSource=conv6[2]
-}}}
+```
 
-The bracketed index after the layer name selects a weight matrix from *conv6*. Indices start at 0. If an index is not given, 0 is implied.
+The bracketed index after the layer name selects a weight matrix from `conv6`.
+Indices start at 0. If an index is not given, 0 is implied.
 
-Now suppose *conv7* itself takes three inputs. If you want *conv7* to take its first and third weight matrix from other layers, you can do it like this:
+Now suppose `conv7` itself takes three inputs. If you want `conv7` to take its
+first and third weight matrix from other layers, you can do it like this:
 
-{{{
+```ini
 [conv7]
 type=conv
 inputs=conv6,conv5,conv4
 ...
 weightSource=conv3,,conv5[1]
-}}}
+```
 
-Hopefully by now it is clear what this means. The first weight matrix will be taken from *conv3`[0]`*, the second weight matrix will be owned by *conv7* -- not taken from anywhere -- and the third weight matrix will be taken from *conv5`[1]`*.
+Hopefully by now it is clear what this means. The first weight matrix will be
+taken from `conv3[0]`, the second weight matrix will be owned by `conv7` --
+not taken from anywhere -- and the third weight matrix will be taken from
+`conv5[1]`.
 
-One final example. Suppose you want *conv7* to take three inputs but apply the same (newly-defined) filters to all three. In other words, you want *conv7* to share its weights with itself, amongst its three inputs. Then you can write:
+One final example. Suppose you want `conv7` to take three inputs but apply the
+same (newly-defined) filters to all three. In other words, you want `conv7` to
+share its weights with itself, amongst its three inputs. Then you can write:
 
-{{{
+```ini
 [conv7]
 type=conv
 inputs=conv6,conv5,conv4
 ...
 weightSource=,conv7,conv7
-}}}
+```
 
-This says that the first weight matrix of *conv7* will be new, but the remaining two will be equivalent to the first.
+This says that the first weight matrix of `conv7` will be new, but the remaining
+two will be equivalent to the first.
 
-Note that in all cases, biases are never shared between layers. Each layer has its own bias vector.
+Note that in all cases, biases are never shared between layers. Each layer has
+its own bias vector.
 
-== Initializing weights from an outside source ==
+### Initializing weights from an outside source
 
-By default, the net initializes the weights randomly from a normal distribution with standard deviation given by the `initW` parameter. You may want to initialize weights from a different distribution, or perhaps from another model, or from wherever. To do this, add the `initWFunc` parameter to your weight layer, like so:
+By default, the net initializes the weights randomly from a normal distribution
+with standard deviation given by the `initW` parameter. You may want to
+initialize weights from a different distribution, or perhaps from another model,
+or from wherever. To do this, add the `initWFunc` parameter to your weight
+layer, like so:
 
-{{{
+```ini
 [conv8]
 type=conv
 inputs=conv6,conv5
 ...
 initWFunc=winitfile.makew(0.5,3)
-}}}
+```
 
-This says that the weight matrices in this layer will come from a function named `makew` in a python file named `winitfile.py`, located in the same directory as the main code. So now you have to write a python function which will return the weight matrices for this layer.
+This says that the weight matrices in this layer will come from a function named
+`makew` in a python file named `winitfile.py`, located in the same directory as
+the main code. So now you have to write a python function which will return the
+weight matrices for this layer.
 
 Here is a valid `winitfile.py` file for this case:
-{{{
+
+```python
 import numpy as n
 import numpy.random as nr
 
@@ -681,83 +865,113 @@ def makew(name, idx, shape, params=None):
     stdev, mean = float(params[0]), float(params[1])
     rows, cols = shape
     return n.array(mean + stdev * nr.randn(rows, cols), dtype=n.single)
-}}}
+```
 
-This doesn't do anything useful, really -- it just initializes the weights from a normal distribution with mean 3 and standard deviation 0.5.
+This doesn't do anything useful, really -- it just initializes the weights from
+a normal distribution with mean 3 and standard deviation 0.5.
 
-But the above example should make clear the constraints on the weight-creating function.
-  * It must take four parameters:
-    # `name`: the layer name (in this example it would be *conv8*).
-    # `idx`: the weight matrix index within that layer. In this example it would be 0 when called to initialize the *conv6*-connected weight matrix and 1 when called to initialize the *conv5*-connected weight matrix.
-    # `shape`: a 2-tuple of (rows, columns) indicating the dimensions of the required weight matrix.
-    # `params`: a keyword parameter which receives a list of string parameters that you can specify in the `initWFunc` definition (as we did above).
-  * It must return a `numpy.ndarray` object consisting of single-precision floats.
+But the above example should make clear the constraints on the weight-creating
+function.
 
-A typical use case for this might be to have the `makew` function load a weight matrix from some other model and return it. Note that you can easily load weight matrices stored as Matlab objects with the [http://docs.scipy.org/doc/scipy/reference/generated/scipy.io.loadmat.html scipy.io.loadmat] function.
+* It must take four parameters:
+  * `name`: the layer name (in this example it would be `conv8`).
+  * `idx`: the weight matrix index within that layer. In this example it would
+    be 0 when called to initialize the `conv6`-connected weight matrix and 1
+    when called to initialize the `conv5`-connected weight matrix.
+  * `shape`: a 2-tuple of (rows, columns) indicating the dimensions of the
+    required weight matrix.
+  * `params`: a keyword parameter which receives a list of string parameters
+    that you can specify in the `initWFunc` definition (as we did above).
+* It must return a `numpy.ndarray` object consisting of single-precision floats.
 
-Note that you don't have to pass parameters to your weight-creating function. The following line is also valid:
-{{{
+A typical use case for this might be to have the `makew` function load a weight
+matrix from some other model and return it. Note that you can easily load weight
+matrices stored as Matlab objects with the
+[`scipy.io.loadmat`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.loadmat.html)
+function.
+
+Note that you don't have to pass parameters to your weight-creating function.
+The following line is also valid:
+
+```ini
 initWFunc=winitfile.makew
-}}}
+```
 
 In this case the `params` argument in `makew` will be the empty list `[]`.
 
-You might be wondering what dimensions (shapes) the weight matrices that your function returns should have. The following table lists this:
+You might be wondering what dimensions (shapes) the weight matrices that your
+function returns should have. The following table lists this:
 
-|| *Layer type* || *Matrix rows* || *Matrix columns* || *Notes* ||
-||[LayerParams#Fully-connected_layer Fully-connected]||`input size`||`output size`|| ||
-||[LayerParams#Convolution_layer Convolutional]||`filterSize`^2^ x `filterChannels`||`filters`|| `filterChannels` is the number of channels each filter is connected to. This is equal to the number of channels in the input unless you're using [LayerParams#Block_sparse_convolution_layer sparsity].||
-||[LayerParams#Locally-connected_layer_with_unshared_weights Locally-connected]||`outputsX`^2^ x `filterSize`^2^ x `filterChannels`||`filters`|| This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filters in the _x_ (equivalently, _y_) direction in this layer.||
+| Layer type | Matrix rows | Matrix columns | Notes |
+|------------|-------------|----------------|-------|
+| [Fully-connected](#fully-connected-layer) | `input size` | `output size` | |
+| [Convolutional](#convolution-layer) | `filterSize`<sup>2</sup> x `filterChannels` | `filters` | `filterChannels` is the number of channels each filter is connected to. This is equal to the number of channels in the input unless you're using [sparsity](#block-sparse-convolution-layer). |
+| [Locally-connected](#locally-connected-layer-with-unshared-weights) | `outputsX`<sup>2</sup> x `filterSize`<sup>2</sup> x `filterChannels` | `filters` | This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filters in the _x_ (equivalently, _y_) direction in this layer.|
 
-At present, the function you define *must* return a weight matrix for every input that your layer takes. This means that it's impossible to define a layer in which one weight matrix is shared from another layer while another weight matrix is returned by a custom initialization file. In the future this should be possible.
+At present, the function you define *must* return a weight matrix for every
+input that your layer takes. This means that it's impossible to define a layer
+in which one weight matrix is shared from another layer while another weight
+matrix is returned by a custom initialization file. In the future this should be
+possible.
 
-=== Initializing biases ===
+#### Initializing biases
 
-Each weight layer has a learned bias vector, and it too can be initialized from an outside source. To do this, add the `initBFunc` parameter to your layer definition:
+Each weight layer has a learned bias vector, and it too can be initialized from
+an outside source. To do this, add the `initBFunc` parameter to your layer
+definition:
 
-{{{
+```ini
 [conv8]
 type=conv
 inputs=conv6,conv5
 ...
 initWFunc=winitfile.makew(0.5,3)
 initBFunc=winitfile.makeb
-}}}
+```
 
-The bias vector will now be initialized from the function `makeb` in the python file `winitfile.py`. Here's a valid `makeb` function:
+The bias vector will now be initialized from the function `makeb` in the python
+file `winitfile.py`. Here's a valid `makeb` function:
 
-{{{
-...
-
+```python
 def makeb(name, shape, params=None):
     return n.array(0.01 * nr.randn(shape[0], shape[1]), dtype=n.single)
-}}}
+```
 
-The only difference between the interfaces for the `makew` function and the `makeb` function is that the `makeb` function takes no `idx` parameter since each layer only has one bias vector.
+The only difference between the interfaces for the `makew` function and the
+`makeb` function is that the `makeb` function takes no `idx` parameter since
+each layer only has one bias vector.
 
-The table below lists the shapes of the bias vectors for the various weight layers:
+The table below lists the shapes of the bias vectors for the various weight
+layers:
 
-|| *Layer type* || *Matrix rows* || *Matrix columns* || *Notes* ||
-||[LayerParams#Fully-connected_layer Fully-connected]||`1`||`output size`|| ||
-||[LayerParams#Convolution_layer Convolutional] - shared biases||`1`||`filters`|| ||
-||[LayerParams#Convolution_layer Convolutional] - non-shared biases||`1`||`filters` x `outputsX`^2^|| This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filter applications in the _x_ (equivalently, _y_) direction in this layer. ||
-||[LayerParams#Locally-connected_layer_with_unshared_weights Locally-connected]||`1`||`filters` x `outputsX`^2^|| This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filters in the _x_ (equivalently, _y_)direction in this layer.||
+| Layer type | Matrix rows | Matrix columns | Notes |
+|------------|-------------|----------------|-------|
+| [Fully-connected](#fully-connected-layer) | `1` | `output size` | |
+| [Convolutional](#convolution-layer) - shared biases | `1` | `filters` | |
+| [Convolutional](#convolution-layer) - non-shared biases | `1` | `filters` x `outputsX`<sup>2</sup> | This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filter applications in the _x_ (equivalently, _y_) direction in this layer. |
+| [Locally-connected](#locally-connected-layer-with-unshared-weights) | `1` | `filters` x `outputsX`<sup>2</sup> | This layer produces output of shape `filters` x `outputsX` x `outputsX`. So `outputsX` is the number of filters in the _x_ (equivalently, _y_) direction in this layer.|
 
-= Layer parameter file  - slightly more advanced features =
-==Weight layers with multiple inputs==
-Layers with weights (convolutional, locally-connected, and fully-connected) which also take multiple inputs must specify a learning rate, weight momentum, and weight decay coefficient for each of their weight matrices.
+## Layer parameter file  - slightly more advanced features
 
-For example, the parameter file definition for the layer *conv5b* (defined above) is this:
+### Weight layers with multiple inputs
 
-{{{
+Layers with weights (convolutional, locally-connected, and fully-connected)
+which also take multiple inputs must specify a learning rate, weight momentum,
+and weight decay coefficient for each of their weight matrices.
+
+For example, the parameter file definition for the layer `conv5b` (defined
+above) is this:
+
+```ini
 [conv5b]
 epsW=0.001,0.001
 epsB=2
 momW=0.9,0.9
 momB=0.9
 wc=0.001,0.001
-}}}
+```
 
-= Training the net =
+## Training the net
 
-See TrainingNet for details about how to actually cause training to happen.
+See [training net](TrainingNet.md) for details about how to actually cause
+training to happen.

--- a/docs/Methodology.md
+++ b/docs/Methodology.md
@@ -1,53 +1,115 @@
-#summary How to obtain good performance.
+# How to obtain good performance
 
-= Introduction =
+## Introduction
 
-Here I'll describe the procedure I used to obtain the [http://www.cs.toronto.edu/~kriz/cifar.html CIFAR-10] scores mentioned on the front page. Skip this section if you're just interested in the convolutional net code, not the details of how the CIFAR-10 scores were obtained.
+Here I'll describe the procedure I used to obtain the
+[CIFAR-10](http://www.cs.toronto.edu/~kriz/cifar.html) scores mentioned on the
+front page. Skip this section if you're just interested in the convolutional net
+code, not the details of how the CIFAR-10 scores were obtained.
 
-= Methodology =
+## Methodology
 
-I'll use the 13% test error score as the example. You can download the layer definition file [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/layers-conv-local-13pct.cfg here] and the layer parameter file [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/layer-params-conv-local-13pct.cfg here].
+I'll use the 13% test error score as the example. You can download the [layer
+definition file](../example-layers/layers-conv-local-13pct.cfg) and the [layer
+parameter file](../example-layers/layer-params-conv-local-13pct.cfg).
 
-We will be training on random 24x24 patches extracted from the 32x32 CIFAR-10 images. You can read a bit more about that [http://code.google.com/p/cuda-convnet/wiki/TrainingNet#Training_on_image_translations here].
+We will be training on random 24x24 patches extracted from the 32x32 CIFAR-10
+images. You can read a bit more about that
+[here](TrainingNet.md#Training_on_image_translations).
 
-We'll be using a version of the CIFAR-10 in which all the data matrices have been transposed (because that format is convenient for this code). You can download it [http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz here]. It's the same version as is used in [Data other sections] of this wiki.
+We'll be using a version of the CIFAR-10 in which all the data matrices have
+been transposed (because that format is convenient for this code). You can
+download it [here](http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz).
+It's the same version as is used in [other sections](Data.md) of these docs.
 
-We'll use batches 1-4 for training and batch 5 for validation (early stopping). Batch 6 of course is the test set.
+We'll use batches 1-4 for training and batch 5 for validation (early stopping).
+Batch 6 of course is the test set.
 
-  # Start by training the net on batches 1-4 and "testing" on batch 5. Train until the validation error stops improving. Since I've run this net before, I know that this happens after roughly 100 epochs. So we start the net with the parameters `--train-range=1-4`, `--test-range=5`, and `--epochs=100`. Like so:
-{{{
-python convnet.py --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ --save-path=/storage2/tmp --test-range=5 --train-range=1-4 --layer-def=./example-layers/layers-conv-local-13pct.cfg --layer-params=./example-layers/layer-params-conv-local-13pct.cfg --data-provider=cifar-cropped --test-freq=13 --crop-border=4 --epochs=100
-}}}
-  # Now note the *training error* after the above run has finished. In this case, it is roughly 0.4 [http://en.wikipedia.org/wiki/Nat_(information) nats]:
-{{{
+Start by training the net on batches 1-4 and "testing" on batch 5. Train until
+the validation error stops improving. Since I've run this net before, I know
+that this happens after roughly 100 epochs. So we start the net with the
+parameters `--train-range=1-4`, `--test-range=5`, and `--epochs=100`. Like so:
+
+```sh
+python convnet.py \
+    --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ \
+    --save-path=/storage2/tmp \
+    --test-range=5 \
+    --train-range=1-4 \
+    --layer-def=./example-layers/layers-conv-local-13pct.cfg \
+    --layer-params=./example-layers/layer-params-conv-local-13pct.cfg \
+    --data-provider=cifar-cropped \
+    --test-freq=13 \
+    --crop-border=4 \
+    --epochs=100
+```
+
+Now note the *training error* after the above run has finished. In this case, it
+is roughly 0.4 [nats](https://en.wikipedia.org/wiki/Nat_(information) ):
+
+```
 100.2... logprob:  0.418657, 0.145800 (1.857 sec)
 100.3... logprob:  0.405222, 0.141100 (1.862 sec)
 100.4... logprob:  0.419132, 0.145400 (1.857 sec)
 101.1... logprob:  0.394249, 0.137100 (1.855 sec)
-}}}
-  # Now we'll resume training, but this time on all 5 batches of the CIFAR-10 training set. We will stop training when the *training error on batch 5* (which used to be our validation set) reaches 0.4 nats. Because I have done this before, I know this takes roughly 40 more epochs. So we run the net like this:
-{{{
-python convnet.py -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 --train-range=1-5 --epochs=140
-}}}
-  # Now we reduce all learning rates (the `epsW` parameters) in the [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/layer-params-conv-local-13pct.cfg layer parameter file] by a factor of 10, and train for another 10 epochs:
-{{{
-python convnet.py -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 --epochs=150
-}}}
-  # Reduce all learning rates in the layer parameter file by *another* factor of 10, and train for *another* 10 epochs:
-{{{
-python convnet.py -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 --epochs=160
-}}}
-  # Finally, substitute the real test set, and test on it using the procedure described [TrainingNet#Training_on_image_translations here]:
-{{{
-python convnet.py -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 --multiview-test=1 --test-only=1 --logreg-name=logprob --test-range=6
-}}}
-  # You should see output that looks something like this, in this case indicating a 12.6% test error.
-{{{
+```
+
+Now we'll resume training, but this time on all 5 batches of the CIFAR-10
+training set. We will stop training when the *training error on batch 5* (which
+used to be our validation set) reaches 0.4 nats. Because I have done this
+before, I know this takes roughly 40 more epochs. So we run the net like this:
+
+```sh
+python convnet.py \
+    -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 \
+    --train-range=1-5 \
+    --epochs=140
+```
+
+Now we reduce all learning rates (the `epsW` parameters) in the
+[layer parameter file](../example-layers/layer-params-conv-local-13pct.cfg) by a
+factor of 10, and train for another 10 epochs:
+
+```sh
+python convnet.py \
+    -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 \
+    --epochs=150
+```
+
+Reduce all learning rates in the layer parameter file by *another* factor of 10,
+and train for *another* 10 epochs:
+
+```sh
+python convnet.py \
+    -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 \
+    --epochs=160
+```
+
+Finally, substitute the real test set, and test on it using the procedure
+described [here](TrainingNet.md#training-on-image-translations):
+
+```sh
+python convnet.py \
+    -f /storage2/tmp/ConvNet__2011-12-17_18.13.52 \
+    --multiview-test=1 \
+    --test-only=1 \
+    --logreg-name=logprob \
+    --test-range=6
+```
+
+You should see output that looks something like this, in this case indicating a 12.6% test error.
+
+```
 ======================Test output======================
 logprob:  0.423908, 0.126000
-}}}
+```
 
 Notes:
-  * During step 3, you will see test error printouts that are very low -- this is because the net is testing on batch 5, on which it is also training. But it is testing on only the *center patches*, while it is training on all patches.
-  * The test error will of course fluctuate slightly from run to run, so 13% is a conservative estimate.
-  * The total training time in this case is 1.86 seconds x 4 batches x 100 epochs + 1.86 seconds x 5 batches x 60 epochs = *21.7 minutes*.
+
+* During step 3, you will see test error printouts that are very low -- this is
+  because the net is testing on batch 5, on which it is also training. But it is
+  testing on only the *center patches*, while it is training on all patches.
+* The test error will of course fluctuate slightly from run to run, so 13% is a
+  conservative estimate.
+* The total training time in this case is 1.86 seconds x 4 batches x 100 epochs
+  + 1.86 seconds x 5 batches x 60 epochs = *21.7 minutes*.

--- a/docs/NeuronTypes.md
+++ b/docs/NeuronTypes.md
@@ -1,22 +1,25 @@
-#summary The types of neurons (hidden unit nonlinearities) supported by the net.
+# Neuron types
 
-= Neuron types =
+The types of neurons (hidden unit nonlinearities) supported by the net.
 
-Most of the [LayerParams layer types] take a `neuron=x` parameter, which defines the output nonlinearity of neurons in the layer.
+Most of the [layer types](LayerParams.md) take a `neuron=x` parameter, which
+defines the output nonlinearity of neurons in the layer.
 
 These are the supported neuron types:
 
-|| *Parameter* || *Name* || *Function* ||
-|| `neuron=logistic`||logistic || http://cuda-convnet.googlecode.com/svn/wiki/images/logistic.gif||
-||`neuron=tanh[a,b]` ||hyperbolic tangent || http://cuda-convnet.googlecode.com/svn/wiki/images/tanh.gif||
-|| `neuron=relu`||rectified linear || http://cuda-convnet.googlecode.com/svn/wiki/images/relu.gif||
-|| `neuron=brelu[a]`||bounded rectified linear || http://cuda-convnet.googlecode.com/svn/wiki/images/brelu.gif||
-|| `neuron=softrelu`||soft rectified linear || http://cuda-convnet.googlecode.com/svn/wiki/images/softrelu.gif||
-|| `neuron=abs`||absolute value || http://cuda-convnet.googlecode.com/svn/wiki/images/abs.gif||
-|| `neuron=square`||square || http://cuda-convnet.googlecode.com/svn/wiki/images/square.gif||
-|| `neuron=sqrt`||square root || http://cuda-convnet.googlecode.com/svn/wiki/images/sqrt.gif||
-|| `neuron=linear[a,b]`||linear || http://cuda-convnet.googlecode.com/svn/wiki/images/linear.gif||
+| Parameter | Name | Function |
+|-----------|------|----------|
+| `neuron=logistic` | logistic | ![](images/logistic.gif) |
+|`neuron=tanh[a,b]` | hyperbolic tangent | ![](images/tanh.gif) |
+| `neuron=relu` | rectified linear | ![](images/relu.gif) |
+| `neuron=brelu[a]` | bounded rectified linear | ![](images/brelu.gif) |
+| `neuron=softrelu` | soft rectified linear | ![](images/softrelu.gif) |
+| `neuron=abs` | absolute value | ![](images/abs.gif) |
+| `neuron=square` | square | ![](images/square.gif) |
+| `neuron=sqrt` | square root | ![](images/sqrt.gif) |
+| `neuron=linear[a,b]` | linear | ![](images/linear.gif) |
 
 _x_, _a_, and _b_ above are all scalars.
 
-Adding new types of neurons is easy. See [http://code.google.com/p/cuda-convnet/source/browse/trunk/include/neuron.cuh neuron.cuh] for reference.
+Adding new types of neurons is easy. See [`neuron.cuh`](../include/neuron.cuh)
+for reference.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -1,15 +1,16 @@
-#summary The command-line arguments that this code takes.
+# The command-line arguments that this code takes
 
-= Introduction =
+## Introduction
 
 If you type
-{{{
+
+```sh
 python convnet.py
-}}}
+```
 
 You should get the following output, briefly describing the command-line arguments that this code expects:
 
-{{{
+```
 convnet.py usage:
     Option                             Description                                          Default
     [--check-grads <0/1>           ] - Check gradients and quit?                            [0]
@@ -36,41 +37,44 @@ convnet.py usage:
      --save-path <string>            - Save path
      --test-range <int[-int]>        - Data batch range: testing
      --train-range <int[-int]>       - Data batch range: training
-}}}
+```
 
 You can see that most arguments have default values, so you don't have to provide them.
 
 The angle brackets following the argument names tell you what kind of value each argument expects.
 
-= What they mean =
+## What they mean
 
 First the optional arguments:
-|| *Argument* || *Meaning* ||
-|| `--check-grads` || [CheckingGradients Check the gradients] ||
-|| `--conserve-mem` || Conserve GPU memory by deleting activity and gradient matrices when they're not needed. This will slow down the net but it will allow you to run larger nets.||
-|| `--conv-to-local` || Convert the specified layers from convolutional to unshared, locally-connected. See [TrainingNet#Convert_convolutional_layers_to_unshared,_locally-connected_laye TrainingNet] for details. ||
-|| `--crop-border` || When using a data provider that crops images (for example if you want to train on translations of the CIFAR-10), this specifies the size of the cropped region in pixels. The `cifar-cropped` data provider does this. ||
-|| `--epochs` || How many epochs to train for. An epoch is one pass through the training data. ||
-|| `-f` || Load checkpoint from given path. All other arguments become optional when this is given. ||
-|| `--gpu` || Set GPU index to run on (default is to grab fastest GPU available). ||
-|| `--logreg-name` || The name of the logistic regression cost objective. To be used in conjunction with the *--crop-border* and *--multiview-test* argument. ||
-|| `--max-filesize` || Maximum amount of disk space occupied by all checkpoints. Set to 0 to only store last checkpoint. ||
-|| `--mini` || Minibatch size. The minibatch size is the number of training cases over which the gradient is averaged to produce a weight update. *For best performance this value should be a multiple of 128.* In particular, this code is in no way designed for on-line learning (i.e. minibatch size of 1). So while a minibatch size of 1 will work, processing 1 image may in general take almost as much time as processing a minibatch of 128 images. ||
-|| `--multiview-test` || When using a data provider that crops images, this indicates that the test error computation should be averaged over several regions of the image rather than just the center region. To be used in conjunction with the *--crop-border* and *--logreg-name* arguments. Note that this will greatly increase the time it takes to compute the test error. So it's best to leave this off until you're done training, at which point you can compute the averaged test error once using this option in conjunction with the *--test-only* option. ||
-|| `--num-gpus` || Ignore this. This code does not support training one model on multiple GPUs. ||
-|| `--test-freq` || The test error computation / checkpoint saving frequency, in units of training batches. Every *this many* training batches,  the net will compute the test error and save a checkpoint.||
-|| `--test-one` || If multiple testing batches are given, each test output will be computed on only one of the batches. The net will cycle through them in sequence. ||
-|| `--test-only` || Compute the test error and quit. To be used in combination with the *-f* option. ||
-|| `--unshare-weights` || Remove the coupling of weight matrices between layers. See [TrainingNet#Decouple_weight_matrices_between_layers TrainingNet] for details. ||
-|| `--zip-save` || Compress checkpoint files. This makes checkpointing slower and may have almost no effect on the file size. So the default is off. ||
+
+| Argument | Meaning |
+|----------|---------|
+| `--check-grads` | [Check the gradients](CheckingGradients.md) |
+| `--conserve-mem` | Conserve GPU memory by deleting activity and gradient matrices when they're not needed. This will slow down the net but it will allow you to run larger nets.|
+| `--conv-to-local` | Convert the specified layers from convolutional to unshared, locally-connected. See [TrainingNet](TrainingNet.md#Convert_convolutional_layers_to_unshared,_locally-connected_laye) for details. |
+| `--crop-border` | When using a data provider that crops images (for example if you want to train on translations of the CIFAR-10), this specifies the size of the cropped region in pixels. The `cifar-cropped` data provider does this. |
+| `--epochs` | How many epochs to train for. An epoch is one pass through the training data. |
+| `-f` | Load checkpoint from given path. All other arguments become optional when this is given. |
+| `--gpu` | Set GPU index to run on (default is to grab fastest GPU available). |
+| `--logreg-name` | The name of the logistic regression cost objective. To be used in conjunction with the `--crop-border` and `--multiview-test` argument. |
+| `--max-filesize` | Maximum amount of disk space occupied by all checkpoints. Set to 0 to only store last checkpoint. |
+| `--mini` | Minibatch size. The minibatch size is the number of training cases over which the gradient is averaged to produce a weight update. *For best performance this value should be a multiple of 128.* In particular, this code is in no way designed for on-line learning (i.e. minibatch size of 1). So while a minibatch size of 1 will work, processing 1 image may in general take almost as much time as processing a minibatch of 128 images. |
+| `--multiview-test` | When using a data provider that crops images, this indicates that the test error computation should be averaged over several regions of the image rather than just the center region. To be used in conjunction with the `--crop-border` and `--logreg-name` arguments. Note that this will greatly increase the time it takes to compute the test error. So it's best to leave this off until you're done training, at which point you can compute the averaged test error once using this option in conjunction with the `--test-only` option. |
+| `--num-gpus` | Ignore this. This code does not support training one model on multiple GPUs. |
+| `--test-freq` | The test error computation / checkpoint saving frequency, in units of training batches. Every *this many* training batches,  the net will compute the test error and save a checkpoint.|
+| `--test-one` | If multiple testing batches are given, each test output will be computed on only one of the batches. The net will cycle through them in sequence. |
+| `--test-only` | Compute the test error and quit. To be used in combination with the `-f` option. |
+| `--unshare-weights` | Remove the coupling of weight matrices between layers. See [TrainingNet](TrainingNet.md#decoupling-weight-matrices-between-layers) for details. |
+| `--zip-save` | Compress checkpoint files. This makes checkpointing slower and may have almost no effect on the file size. So the default is off. |
 
 Now the mandatory ones:
 
-|| *Argument* || *Meaning* ||
-|| --data-path || The path where the net's [Data data provider] can find its data. ||
-|| --data-provider || The [Data data provider] to use to parse the data. ||
-|| --layer-def || The [LayerParams#Layer_definition_file layer definition] file. ||
-|| --layer-params || The [LayerParams#Layer_parameter_file layer parameter] file. ||
-|| --save-path || The path to which the net should save checkpoints. ||
-|| --test-range || The data [Data batches] that the net should use to compute the test error. ||
-|| --train-range || The data [Data batches] that the net should use for training. ||
+| Argument | Meaning |
+|----------|---------|
+| `--data-path` | The path where the net's [data provider](Data.md) can find its data. |
+| `--data-provider` | The [data provider](Data.md) to use to parse the data. |
+| `--layer-def` | The [layer definition](LayerParams.md#Layer_definition_file) file. |
+| `--layer-params` | The [layer parameter](LayerParams.md#Layer_parameter_file) file. |
+| `--save-path` | The path to which the net should save checkpoints. |
+| `--test-range` | The data [batches](Data.md) that the net should use to compute the test error. |
+| `--train-range` | The data [batches](Data.md) that the net should use for training. |

--- a/docs/TrainingNet.md
+++ b/docs/TrainingNet.md
@@ -1,23 +1,28 @@
-#summary How to train a neural net with this code.
+# How to train a neural net with this code
 
-<font color="red">*Important:*</font> The convolution routines in this code are optimized _only_ for minibatch sizes which are divisible by 128. Other minibatch sizes will work, but I made no attempt to make them work fast.
+**Important:** The convolution routines in this code are optimized _only_ for
+minibatch sizes which are divisible by 128. Other minibatch sizes will work, but
+I made no attempt to make them work fast.
 
-The minibatch size is controlled by the `--mini` parameter (see below). Its default value is 128, which is optimal from the point of view of the convolution routines. So my suggestion is to leave it at its default.
+The minibatch size is controlled by the `--mini` parameter (see below). Its
+default value is 128, which is optimal from the point of view of the convolution
+routines. So my suggestion is to leave it at its default.
 
-<h1>Table of Contents</h1>
-<wiki:toc max_depth="3" />
+## Training
 
-= Training =
+Once you've [compiled](Compiling.md) the code, created a [layer definition
+file](LayerParams.md), and found some [data](Data.md) to train on, you can
+actually do some training.
 
-Once you've [Compiling compiled] the code, created a [LayerParams layer definition file], and found some [Data data] to train on, you can actually do some training.
+Start by typing:
 
-Start by typing
-{{{
+```sh
 python convnet.py
-}}}
+```
 
 You should get the following output:
-{{{
+
+```
 convnet.py usage:
     Option                             Description                                          Default
     [--check-grads <0/1>           ] - Check gradients and quit?                            [0]
@@ -43,23 +48,45 @@ convnet.py usage:
      --save-path <string>            - Save path
      --test-range <int[-int]>        - Data batch range: testing
      --train-range <int[-int]>       - Data batch range: training
-}}}
+```
 
-You can read about the meanings of these options [Options here].
+You can read about the meanings of these options [here](Options.md).
 
-You see that you need to provide a data path, a save (checkpointing) path, some parameters to do with which chunks to train on and which chunks to test on, and the layer definition files described [LayerParams here].
+You see that you need to provide a data path, a save (checkpointing) path, some
+parameters to do with which chunks to train on and which chunks to test on, and
+the layer definition files described [here](LayerParams.md).
 
-The data for this example will be the CIFAR-10 dataset, which you can download [http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz here]. If you're not familiar with the CIFAR-10, you can read about it [http://www.cs.toronto.edu/~kriz/cifar.html here]. We'll use one of the example layer configuration files provided in the [http://code.google.com/p/cuda-convnet/source/browse/trunk/example-layers/ example-layers] subdirectory.
+The data for this example will be the CIFAR-10 dataset, which you can download
+[here](http://www.cs.toronto.edu/~kriz/cifar-10-py-colmajor.tar.gz). If you're
+not familiar with the CIFAR-10, you can read about it
+[here](http://www.cs.toronto.edu/~kriz/cifar.html). We'll use one of the example
+layer configuration files provided in the
+[`../example-layers`](../example-layers) subdirectory.
 
 Try this line, replacing the data and save paths with ones that make sense on your system:
-{{{
-python convnet.py --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ --save-path=/storage2/tmp --test-range=6 --train-range=1-5 --layer-def=./example-layers/layers-19pct.cfg --layer-params=./example-layers/layer-params-19pct.cfg --data-provider=cifar --test-freq=13
-}}}
 
-This will cause the net to train on data located in `/storage2/tiny/cifar-10-batches-py-colmajor/` and save checkpoints to `/storage2/tmp`. It will use batches 1-5 for training and batch 6 for testing. For every 13 training batches it processes, it will compute the test error once. The testing frequency is also the checkpoint saving frequency (read more about this below).
+```sh
+python convnet.py \
+    --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ \
+    --save-path=/storage2/tmp \
+    --test-range=6 \
+    --train-range=1-5 \
+    --layer-def=./example-layers/layers-19pct.cfg \
+    --layer-params=./example-layers/layer-params-19pct.cfg \
+    --data-provider=cifar \
+    --test-freq=13
+```
+
+This will cause the net to train on data located in
+`/storage2/tiny/cifar-10-batches-py-colmajor/` and save checkpoints to
+`/storage2/tmp`. It will use batches 1-5 for training and batch 6 for testing.
+For every 13 training batches it processes, it will compute the test error once.
+The testing frequency is also the checkpoint saving frequency (read more about
+this below).
 
 Once the net is running, it will start producing output:
-{{{
+
+```
 Initialized data layer 'data', producing 3072 outputs
 Initialized data layer 'labels', producing 1 outputs
 Initialized convolutional layer 'conv1', producing 1 groups of 32x32 32-channel output
@@ -71,12 +98,15 @@ Initialized avg-pooling layer 'pool3', producing 4x4 64-channel output
 Initialized fully-connected layer 'fc10', producing 10 outputs
 Initialized softmax layer 'probs', producing 10 outputs
 Initialized logistic regression cost 'logprob'
-}}}
+```
 
-This just tells you the dimensions of all the layers inside your net. Since we never _explicitly_ defined how many outputs each convolutional/pooling layer has, this is good to know.
+This just tells you the dimensions of all the layers inside your net. Since we
+never _explicitly_ defined how many outputs each convolutional/pooling layer
+has, this is good to know.
 
 Then this:
-{{{
+
+```
 Check gradients and quit?            : 0   [DEFAULT]
 Compress checkpoints?                : 0   [DEFAULT]
 Cropped DP: crop border size         : 4   [DEFAULT]
@@ -98,12 +128,13 @@ Save path                            : /storage2/tmp
 Test and quit?                       : 0   [DEFAULT]
 Test on one batch at a time?         : 1   [DEFAULT]
 Testing frequency                    : 13
-}}}
+```
 
 ... a printout of the command-line arguments with which the net was run.
 
 And finally, it starts training, and produces output like this:
-{{{
+
+```
 Saving checkpoints to /storage2/tmp/ConvNet__2011-06-29_22.19.39
 =========================
 1.1... logprob:  2.277909, 0.879600 (1.563 sec)
@@ -133,74 +164,134 @@ Saved checkpoint to /storage2/tmp/ConvNet__2011-06-29_22.19.39
 3.5... logprob:  1.481088, 0.526000 (1.399 sec)
 4.1... logprob:  1.456526, 0.525100 (1.396 sec)
 4.2... logprob:  1.449469, 0.517800 (1.396 sec)
-}}}
+```
 
-... which tells you the epoch and batch numbers as well as the values of all of the objectives that you're optimizing. The *cost.logreg* objective happens to return two values -- the average negative log probability of the data under the model (that's the first number) as well as the classification error rate (the second number). You can see that the net here is at 55.34% classification error on the test set. This net will continue training until the epoch number exceeds that given to the *--epochs* [Options argument] (default 50000).
+... which tells you the epoch and batch numbers as well as the values of all of
+the objectives that you're optimizing. The *cost.logreg* objective happens to
+return two values -- the average negative log probability of the data under the
+model (that's the first number) as well as the classification error rate (the
+second number). You can see that the net here is at 55.34% classification error
+on the test set. This net will continue training until the epoch number exceeds
+that given to the *--epochs* [argument](Options.md) (default 50000).
 
-Every time the net prints a test output, it also saves a checkpoint to the path printed. The number of checkpoints that it maintains is controlled by the *--max-filesize* parameter. See [Options] for more on this parameter.
+Every time the net prints a test output, it also saves a checkpoint to the path
+printed. The number of checkpoints that it maintains is controlled by the
+*--max-filesize* parameter. See [options](Options.md) for more on this parameter.
 
-Included with the test output are measures of the magnitudes of the net's weights and weight increments (in square brackets). Specifically, the net is printing the average absolute value of each weight matrix and each weight matrix increment. This output is useful for spotting learning rates that are too low (or too high), causing weights to stagnate (or blow up).
+Included with the test output are measures of the magnitudes of the net's
+weights and weight increments (in square brackets). Specifically, the net is
+printing the average absolute value of each weight matrix and each weight matrix
+increment. This output is useful for spotting learning rates that are too low
+(or too high), causing weights to stagnate (or blow up).
 
-If you want to change the learning parameters you specified, you can just kill the net with Ctrl-C (or kill -9, etc.), change the learning parameters in `./example-layers/layer-params-19pct.cfg`, and then restart the net like this:
+If you want to change the learning parameters you specified, you can just kill
+the net with Ctrl-C (or kill -9, etc.), change the learning parameters in
+`./example-layers/layer-params-19pct.cfg`, and then restart the net like this:
 
-{{{
+```sh
 python convnet.py -f /storage2/tmp/ConvNet__2011-06-29_22.19.39
-}}}
+```
 
-The net will resume from the last checkpoint. If you want to resume from an earlier checkpoint, pass a specific checkpoint file inside `/storage2/tmp/ConvNet__2011-06-29_22.19.39` to the *-f* parameter. The checkpoint files are numbered by their epoch and batch numbers.
+The net will resume from the last checkpoint. If you want to resume from an
+earlier checkpoint, pass a specific checkpoint file inside
+`/storage2/tmp/ConvNet__2011-06-29_22.19.39` to the `-f` parameter. The
+checkpoint files are numbered by their epoch and batch numbers.
 
-== Training on image translations ==
+### Training on image translations
 
-Most image classification results can be improved by training on slight translations of the original images. This is an easy way to multiply the amount of training data available, and hence combat over-fitting.
+Most image classification results can be improved by training on slight
+translations of the original images. This is an easy way to multiply the amount
+of training data available, and hence combat over-fitting.
 
-This code ships with a data provider that's capable of training on translations of the CIFAR-10, and it isn't hard to adapt it to other datasets. Given the CIFAR-10, though, here's how you can train on random 24x24 patches of the original 32x32 images:
+This code ships with a data provider that's capable of training on translations
+of the CIFAR-10, and it isn't hard to adapt it to other datasets. Given the
+CIFAR-10, though, here's how you can train on random 24x24 patches of the
+original 32x32 images:
 
-{{{
-python convnet.py --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ --save-path=/storage2/tmp --test-range=6 --train-range=1-5 -layer-def=./example-layers/layers-19pct.cfg --layer-params=./example-layers/layer-params-19pct.cfg --data-provider=cifar-cropped --crop-border=4 --test-freq=13
-}}}
+```sh
+python convnet.py \
+    --data-path=/storage2/tiny/cifar-10-batches-py-colmajor/ \
+    --save-path=/storage2/tmp \
+    --test-range=6 \
+    --train-range=1-5 \
+    -layer-def=./example-layers/layers-19pct.cfg \
+    --layer-params=./example-layers/layer-params-19pct.cfg \
+    --data-provider=cifar-cropped \
+    --crop-border=4 \
+    --test-freq=13
+```
 
-This will cause the net to train on random 24x24 patches and test on the center 24x24 patch.
+This will cause the net to train on random 24x24 patches and test on the center
+24x24 patch.
 
-Notice that the only difference between this run line and the one above is that the data provider has been changed to *cifar-cropped* and we've also added a *--crop-border=4* argument which indicates the amount of cropping.
+Notice that the only difference between this run line and the one above is that
+the data provider has been changed to `cifar-cropped` and we've also added a
+`--crop-border=4` argument which indicates the amount of cropping.
 
-After training is done, you can kill the net and re-run it with the *--test-only=1* and *--multiview-test=1* arguments to compute the test error as averaged over 10 patches of the original images (4 corner patches, center patch, and their horizontal reflections). This will produce better results than testing on the center patch alone.
+After training is done, you can kill the net and re-run it with the
+`--test-only=1` and `--multiview-test=1` arguments to compute the test error as
+averaged over 10 patches of the original images (4 corner patches, center patch,
+and their horizontal reflections). This will produce better results than testing
+on the center patch alone.
 
-= Operations on saved nets =
+## Operations on saved nets
 
-== Converting convolutional layers to unshared, locally-connected layers==
+### Converting convolutional layers to unshared, locally-connected layers
 
-You may be curious what would happen if you simply untied all of the weights in a convolutional layer. This is equivalent to converting a [LayerParams#Convolution_layer convolutional] layer to an [LayerParams#Locally-connected_layer_with_unshared_weights unshared, locally-connected layer]. The net would have many more parameters, as now a different filter would be applied at each location in the input image. But maybe things will get better?
+You may be curious what would happen if you simply untied all of the weights in
+a convolutional layer. This is equivalent to converting a
+[convolutional](LayerParams.md#convolution-layer) layer to an
+[unshared, locally-connected
+layer](LayerParams.md#locally-connected-layer-with-unshared-weights). The net
+would have many more parameters, as now a different filter would be applied at
+each location in the input image. But maybe things will get better?
 
 You can do this like this:
 
-{{{
+```sh
 python convnet.py -f /storage2/tmp/ConvNet__2011-06-29_22.19.39 --conv-to-local=conv3
-}}}
+```
 
-where *conv3* is the name of some convolutional layer in your net. You can specify multiple layers too, with a comma-delimited list of layer names.
+where `conv3` is the name of some convolutional layer in your net. You can
+specify multiple layers too, with a comma-delimited list of layer names.
 
-Note that this operation cannot be reversed, except by loading a checkpoint saved before you did this.
+Note that this operation cannot be reversed, except by loading a checkpoint
+saved before you did this.
 
-== Decoupling weight matrices between layers ==
+### Decoupling weight matrices between layers
 
-If you defined a layer which [LayerParams#Weight_sharing_between_layers takes its weight matrix from another layer], you may decouple the weight matrices like this:
+If you defined a layer which [takes its weight matrix from another
+layer](LayerParams.md#weight-sharing-between-layers), you may decouple the
+weight matrices like this:
 
-{{{
+```sh
 python convnet.py -f /storage2/tmp/ConvNet__2011-06-29_22.19.39 --unshare-weights=conv4
-}}}
+```
 
-where *conv4* is the name of some layer in your net which takes its weight matrix from another layer. If *conv4* takes [LayerParams#Layers_with_multiple_inputs multiple inputs] and you want to decouple a particular weight matrix rather than all of them, you can do this:
+where `conv4` is the name of some layer in your net which takes its weight
+matrix from another layer. If `conv4` takes
+[multiple inputs](LayerParams.md#Layers_with_multiple_inputs) and you want to
+decouple a particular weight matrix rather than all of them, you can do this:
 
-{{{
-python convnet.py -f /storage2/tmp/ConvNet__2011-06-29_22.19.39 --unshare-weights=conv4[3]
-}}}
+```sh
+python convnet.py \
+    -f /storage2/tmp/ConvNet__2011-06-29_22.19.39 \
+    --unshare-weights=conv4[3]
+```
 
-This will decouple the *fourth* weight matrix of *conv4*. Indexing starts at 0.
+This will decouple the *fourth* weight matrix of `conv4`. Indexing starts at 0.
 
-You can also simultaneously decouple weight matrices in multiple layers, by specifying a comma-delimited list of layer names.
+You can also simultaneously decouple weight matrices in multiple layers, by
+specifying a comma-delimited list of layer names.
 
-*Note*: once you've decoupled the weight matrices of two layers, they become two separate, independent entities. This means that they take up twice as much memory. It also means that the *momW* and *wc* parameters that you specified in the layer parameter file for the layer that you just unshared now start being used when updating the newly-created weight matrix.
+*Note*: once you've decoupled the weight matrices of two layers, they become two
+separate, independent entities. This means that they take up twice as much
+memory. It also means that the `momW` and `wc` parameters that you specified in
+the layer parameter file for the layer that you just unshared now start being
+used when updating the newly-created weight matrix.
 
-=Looking inside the net=
+## Looking inside the net
 
-Now that you know how to train the net, you can [ViewingNet read] about how to plot the cost function, look at the filters that your net has learned, and examine the kinds of errors that it makes.
+Now that you know how to train the net, you can [read](ViewingNet.md) about how
+to plot the cost function, look at the filters that your net has learned, and
+examine the kinds of errors that it makes.

--- a/docs/ViewingNet.md
+++ b/docs/ViewingNet.md
@@ -1,52 +1,63 @@
-#summary How to look inside the checkpoints saved by the net.
+# How to look inside the checkpoints saved by the net
 
-<h1>Table of Contents</h1>
-<wiki:toc max_depth="2" />
+## Introduction
 
-= Introduction =
+Included with this code is a basic script called [`shownet.py`](../shownet.py).
+It has three functions:
 
-Included with this code is a basic script called [http://code.google.com/p/cuda-convnet/source/browse/trunk/shownet.py shownet.py]. It has three functions:
-  * to plot the training/test error over time,
-  * to display the filters that the neural net learned, and
-  * to show the predictions (and errors) made by the net.
+* to plot the training/test error over time,
+* to display the filters that the neural net learned, and
+* to show the predictions (and errors) made by the net.
 
-This script requires the [http://matplotlib.sourceforge.net/ matplotlib] python library (package name `python-matplotlib` in Ubuntu and Fedora).
+This script requires the [matplotlib](https://matplotlib.sourceforge.net/) python
+library (package name `python-matplotlib` in Ubuntu and Fedora).
 
-= Details =
+## Details
 
-==Plotting the cost function==
+### Plotting the cost function
+
 To plot the evolution of the value of some cost function over time, call the script like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 --show-cost=logprob
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 \
+    --show-cost=logprob
+```
 
-This will cause the script to open the latest checkpoint at `/storage2/tmp/ConvNet__2011-08-24_16.49.31` and to plot the cost function named `logprob` (which is the name that we happened to give to the cost layer -- see [LayerParams#Logistic_regression_cost_layer]).
+This will cause the script to open the latest checkpoint at
+`/storage2/tmp/ConvNet__2011-08-24_16.49.31` and to plot the cost function named
+`logprob` (which is the name that we happened to give to the cost layer -- see
+[LayerParams#Logistic_regression_cost_layer]).
 
 You should see output that looks something like this:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/cost-function.png
+![](images/cost-function.png)
 
 which plots the training and test error over time.
 
 If your objective returns multiple values (for example the `cost.logreg` objective returns the logprob as well as the classification error), you can plot a particular value like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 --show-cost=logprob --cost-idx=1
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 \
+    --show-cost=logprob \
+    --cost-idx=1
+```
 
 This will plot the classification error rather than the log probability of the data.
 
-==Viewing learned filters==
+### Viewing learned filters
 To view the filters that the net learned, call the script like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 --show-filters=conv32
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 \
+    --show-filters=conv32
+```
 
 This will cause the script to draw the filters in the layer named `conv32`. You should see output that looks something like this:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/filters.png
+![filters](images/filters.png)
 
 Note that you're not likely to get such pretty filters in higher layers. So this visualization is mostly useful only for looking at data-connected layers.
 
@@ -54,57 +65,82 @@ You'll notice that the script has interpreted the 3 channels in the `conv32` lay
 
 An example:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 --show-filters=conv32 --no-rgb=1
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 \
+    --show-filters=conv32 \
+    --no-rgb=1
+```
 
 will produce output that looks like this:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/filters-separated.png
+![](images/filters-separated.png)
 
 Here the 3 channels of each filter are plotted side-by-side in grayscale.
 
 By default, the script shows you the first weight matrix in the layer you've specified. If your layer takes multiple inputs and you'd like to select a particular weight matrix, you can do so with the `--input-idx` parameter:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 --show-filters=conv32 --input-idx=0
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_16.49.31 \
+    --show-filters=conv32 \
+    --input-idx=0
+```
 
-===Viewing learned filters in fully-connected layers===
-There is one extra meta-parameter that the `--show-filters` parameter takes, which is only useful for viewing filters in fully-connected layers.
+#### Viewing learned filters in fully-connected layers
+
+There is one extra meta-parameter that the `--show-filters` parameter takes,
+which is only useful for viewing filters in fully-connected layers.
 
 Running the script like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 --show-filters=fc64  --channels=3
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 \
+    --show-filters=fc64 \
+    --channels=3
+```
 
 produces output that looks like this:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/filters-fc.png
+![filters in fully-connected layers](images/filters-fc.png)
 
-Here the layer name `fc64` given to the `--show-filters` option refers to a fully-connected layer. The extra parameter is `--channels=3`, which specifies the number of channels that the filters in this layer have have. This has to be given because a fully-connected layer looks upon its input as completely flat. It is not aware of channels or image dimensions, etc.
+Here the layer name `fc64` given to the `--show-filters` option refers to a
+fully-connected layer. The extra parameter is `--channels=3`, which specifies
+the number of channels that the filters in this layer have have. This has to be
+given because a fully-connected layer looks upon its input as completely flat.
+It is not aware of channels or image dimensions, etc.
 
-==Viewing test case predictions==
+### Viewing test case predictions
 
 To see the predictions that the net makes on test data, run the script like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 --show-preds=probs
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 \
+    --show-preds=probs
+```
 
 `--show-preds=probs` tells the script the name of the softmax layer whose predictions we wish to view.
 
 You should see output that looks like this:
 
-http://cuda-convnet.googlecode.com/svn/wiki/images/test-preds.png
+![test predictions](images/test-preds.png)
 
-This shows 8 random images from the test set, their true labels, and the 4 labels considered most probable by the model. The true label's probability is shown in red, if it is among the top 4. You can see that in this case the model only got one of the images wrong.
+This shows 8 random images from the test set, their true labels, and the 4
+labels considered most probable by the model. The true label's probability is
+shown in red, if it is among the top 4. You can see that in this case the model
+only got one of the images wrong.
 
 To show _only_ the mis-classified images, run the script like this:
 
-{{{
-python shownet.py -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 --show-preds=1 --logreg-name=logprob --only-errors=1
-}}}
+```sh
+python shownet.py \
+    -f /storage2/tmp/ConvNet__2011-08-24_17.56.48 \
+    --show-preds=1 \
+    --logreg-name=logprob \
+    --only-errors=1
+```
 
-Now the script will only show images for which the true label is different from the model's most-probable label.
+Now the script will only show images for which the true label is different from
+the model's most-probable label.


### PR DESCRIPTION
* fix formatting of headings, code blocks, tables, links, image references, superscripts
* use code formatting instead of italics for layer names written as-is in config
* use GitHub-supported LaTeX formatting to improve readability
* fixed links to code to reflect the new repo structure and avoid SVN-isms
* add syntax highlighting to Python and INI-style configs
* split long command lines into multiple lines with continuation
* word-wrap long lines of text